### PR TITLE
Sanitizer handles invalid utf-8 characters gracefully

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -16,6 +16,9 @@ class CreditCardSanitizer
   def sanitize!(text)
     replaced = nil
 
+    text.force_encoding(Encoding::UTF_8)
+    replace_invalid_characters(text) if !text.valid_encoding?
+
     text.gsub!(NUMBERS_WITH_LINE_NOISE) do |match|
       numbers = match.gsub(/\D/, '')
 
@@ -42,6 +45,14 @@ class CreditCardSanitizer
         @replacement_token
       else
         number
+      end
+    end
+  end
+
+  def replace_invalid_characters(str)
+    for i in (0...str.size)
+      if !str[i].valid_encoding?
+        str[i] = "?"
       end
     end
   end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative 'helper'
 
 class CreditCardSanitizerTest < MiniTest::Test
@@ -44,6 +45,11 @@ class CreditCardSanitizerTest < MiniTest::Test
 
         too_short = 'Hello 49 9273 987 16 there'
         assert_equal nil, @sanitizer.sanitize!(too_short)
+      end
+
+      it "doesn't fail if the text contains invalid utf-8 characters" do
+        invalid_characters = "你好 12 345123 451234 8 \255there"
+        assert_equal '你好 12 3451XX XXX234 8 ?there', @sanitizer.sanitize!(invalid_characters)
       end
     end
 


### PR DESCRIPTION
The sanitizer would fail if an invalid utf-8 character was passed along. This PR replaces the invalid characters by a `?`, so the `sanitize!` method doesn't blow up.

//cc @libo @vkmita @ggrossman 
