### PR TITLE
non-ascii utf8 word characters should not be line noise

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -5,7 +5,7 @@ require 'luhn_checksum'
 class CreditCardSanitizer
 
   # 12-19 digits explanation: https://en.wikipedia.org/wiki/Primary_Account_Number#Issuer_identification_number_.28IIN.29
-  NUMBERS_WITH_LINE_NOISE = /\d(?:\W*\d\W*){10,17}\d/x
+  NUMBERS_WITH_LINE_NOISE = /\d(?:[^\p{L}]*\d[^\p{L}]*){10,17}\d/x
 
   def self.parameter_filter
     Proc.new { |_, value| new.sanitize!(value) if value.is_a?(String) }

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -53,6 +53,11 @@ class CreditCardSanitizerTest < MiniTest::Test
           assert_equal "你好 12 3451XX XXX234 8 \ufffdthere", @sanitizer.sanitize!(invalid_characters)
         end
       end
+
+      it "does not treat proper utf8 word characters as line noise" do
+        invalid_luhn = "12株345123式451社234会8"
+        assert_equal nil, @sanitizer.sanitize!(invalid_luhn)
+      end
     end
 
     describe "#parameter_filter" do


### PR DESCRIPTION
@ggrossman @jcheatham 

This would work, except for 1.8 ree!!!

Any ideas are welcome. Maybe a limit on line noise? 3-5 chars?
