### PR TITLE
Parenthesis should not be considered as line noise

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -4,8 +4,9 @@ require 'luhn_checksum'
 
 class CreditCardSanitizer
 
+  LINE_NOISE = /[^\w_\n,()]{0,8}/x
   # 12-19 digits explanation: https://en.wikipedia.org/wiki/Primary_Account_Number#Issuer_identification_number_.28IIN.29
-  NUMBERS_WITH_LINE_NOISE = /\d(?:[^\w_\n,]{0,8}\d[^\w_\n,]{0,8}){10,17}\d/x
+  NUMBERS_WITH_LINE_NOISE = /\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/x
 
   def self.parameter_filter
     Proc.new { |_, value| new.sanitize!(value) if value.is_a?(String) }

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -70,6 +70,10 @@ class CreditCardSanitizerTest < MiniTest::Test
       it "does not sanitize a credit card number separated by commas" do
         assert_nil @sanitizer.sanitize!("12,345123,451234 8")
       end
+
+      it "does not sanitize credit card numbers separated by parenthesis" do
+        assert_nil @sanitizer.sanitize!("(123)45123-4512-348")
+      end
     end
 
     describe "#parameter_filter" do


### PR DESCRIPTION
@ggrossman 

This makes it so that parens will not be considered as line noise
