### PR TITLE
Colons and forward slashes should not be considered line noise

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -4,7 +4,7 @@ require 'luhn_checksum'
 
 class CreditCardSanitizer
 
-  LINE_NOISE = /[^\w_\n,()]{0,8}/x
+  LINE_NOISE = /[^\w_\n,()\/:]{0,8}/x
   # 12-19 digits explanation: https://en.wikipedia.org/wiki/Primary_Account_Number#Issuer_identification_number_.28IIN.29
   NUMBERS_WITH_LINE_NOISE = /\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/x
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -74,6 +74,14 @@ class CreditCardSanitizerTest < MiniTest::Test
       it "does not sanitize credit card numbers separated by parenthesis" do
         assert_nil @sanitizer.sanitize!("(123)45123-4512-348")
       end
+
+      it "does not sanitize credit card numbers separated by forward slashes" do
+        assert_nil @sanitizer.sanitize!("12/34/5123/4512/348")
+      end
+
+      it "does not sanitize credit card numbers separated by colons" do
+        assert_nil @sanitizer.sanitize!("123:45123:4512:348")
+      end
     end
 
     describe "#parameter_filter" do


### PR DESCRIPTION
@ggrossman 

This makes it so that colons and forward slashes should not be considered line noise
