### PR TITLE
Do not remove urls when a cc number is found in it

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -61,7 +61,7 @@ class CreditCardSanitizer
 
     redacted = nil
     text.gsub!(NUMBERS_WITH_LINE_NOISE) do |match|
-      next if $1
+      next match if $1
       @numbers = match.tr('^0-9', '')
 
       if valid_numbers?

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -89,6 +89,12 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("\"http://support.zendesk.com/tickets/4111111111111111\"")
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
+
+      it "does not mutate the text when there is a url" do
+        url = "http://support.zendesk.com/tickets/4111111111111111"
+        assert_nil @sanitizer.sanitize!(url)
+        assert_equal "http://support.zendesk.com/tickets/4111111111111111", url
+      end
     end
 
     describe "#parameter_filter" do


### PR DESCRIPTION
@ggrossman 

This makes it so we do not remove urls when there is a cc in it.
