### PR TITLE
Try to avoid redacting international phone numbers that look like valid credit card numbers

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,8 +23,8 @@ class CreditCardSanitizer
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
-  SCHEME = /((?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -90,6 +90,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
 
+      it "does not sanitize credit card numbers that start with +" do
+        assert_nil @sanitizer.sanitize!("+4111111111111111")
+        assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
+        assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
+        assert_nil @sanitizer.sanitize!("(+4111111111111111)")
+      end
+
       it "does not mutate the text when there is a url" do
         url = "http://support.zendesk.com/tickets/4111111111111111"
         assert_nil @sanitizer.sanitize!(url)


### PR DESCRIPTION
If a number passes Luhn check and has a major credit card prefix, but starts with `+`, it's probably an international phone number, so don't redact it.

For example, some UK phone numbers start with `+44` (Isle of Man) which could look like a Visa card, since all we know about Visa for sure is that it starts with `4`.

@vkmita
