### PR TITLE
Don't redact credit card numbers if immediately followed by additional digits

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -118,6 +118,11 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 3-2015", @sanitizer.sanitize!("4111 1111 1111 1111 3-2015")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03-2015 asdbhasd", @sanitizer.sanitize!("4111 1111 1111 1111 03-2015 asdbhasd")
       end
+
+      it "does not sanitize a credit card number immediately followed by digits" do
+        assert_nil @sanitizer.sanitize!("41111111111111112")
+        assert_nil @sanitizer.sanitize!("411111111111111123456789")
+      end
     end
 
     describe "#parameter_filter" do


### PR DESCRIPTION
If the first, say, 16 digits of a 23 digit number are a valid credit card number, we currently redact the number. But we probably should not. If the entire number has a prefix which is a valid-looking credit card number, it still is unlikely to actually be a credit card number. For instance, this happens on timestamp numbers in log files.

This PR adjusts the regex slightly so that one additional digit will be picked up if present; if so, that digit should throw off the algorithm and cause the number to not be redacted.

Ref: zd939528

@vkmita
