### PR TITLE
ZD#1045725 Make NUMBERS_WITH_LINE_NOISE checking a little less greedy/slow

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -30,6 +30,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal 'My cc is 411111▇▇▇▇▇▇1111, I repeat, 411111▇▇▇▇▇▇1111', @sanitizer.sanitize!('My cc is 4111111111111111, I repeat, 4111111111111111')
       end
 
+      it "finishes in a reasonable amount of time with spacey input" do
+        input = "Hello  0      0      0     14     20      1      1     20     34      9      1      0      0      0      0      0"
+        Timeout.timeout(3) do
+          assert_nil @sanitizer.sanitize!(input)
+        end
+      end
+
       it "has a configurable replacement character" do
         sanitizer = CreditCardSanitizer.new(replacement_token: '*')
         assert_equal 'Hello 4111 11**** **111 1 there', sanitizer.sanitize!('Hello 4111 111111 11111 1 there')


### PR DESCRIPTION
@ggrossman @vkmita 

![We made rubular sad](https://cloud.githubusercontent.com/assets/1170999/7128524/3bfab70a-e208-11e4-8653-4f014a6da035.png)

This seemed like the most natural fix... if we really want up to 10 noise characters in between numbers we should probably specify them in a single group to prevent making the internet sad.