### PR TITLE
Detect html code for + character

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
-  SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   attr_reader :replacement_token, :expose_first, :expose_last

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -102,6 +102,7 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
         assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
         assert_nil @sanitizer.sanitize!("(+4111111111111111)")
+        assert_nil @sanitizer.sanitize!("&#43;4111111111111111")
       end
 
       it "does not mutate the text when there is a url" do


### PR DESCRIPTION
Modify credit card redaction regex to detect the ascii code for the `+` character (`&#43;`).

/cc @zendesk/sustaining 

### References
- https://support.zendesk.com/agent/tickets/1221399

### Risks
- Low: Some numbers are incorrectly auto-redacted