### PR TITLE
Prevent HTML Entities from being captured as line noise

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,7 +23,7 @@ class CreditCardSanitizer
   }
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:]{,5}/
+  LINE_NOISE = /[^\w_\n,()\/:;]{,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -102,7 +102,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
         assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
         assert_nil @sanitizer.sanitize!("(+4111111111111111)")
-        assert_nil @sanitizer.sanitize!("&#43;4111111111111111")
+      end
+
+      it "does not sanitize numbers that include a numeric html entity" do
+        assert_nil @sanitizer.sanitize!("&#43; 1 936 321 1111")
       end
 
       it "does not mutate the text when there is a url" do


### PR DESCRIPTION
Fixes issue https://github.com/zendesk/credit_card_sanitizer/issues/25 by removing the semicolon from the acceptable line noise

/cc @zendesk/sustaining @ggrossman 

### Risks
- Low: Some numbers are not correctly auto-redacted