### PR TITLE
Prevent numbers across html tags from being redacted

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,7 +23,7 @@ class CreditCardSanitizer
   }
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:;]{,5}/
+  LINE_NOISE = /[^\w_\n,()\/:;<>]{,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -97,6 +97,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
 
+      it "does not sanitize credit card numbers that are part of an html tag" do
+        assert_nil @sanitizer.sanitize!('<a href="/tickets/40004595">#40004595</a>')
+      end
+
       it "does not sanitize credit card numbers that start with +" do
         assert_nil @sanitizer.sanitize!("+4111111111111111")
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")


### PR DESCRIPTION
Removes `<` and `>` from the acceptable line noise so that credit card numbers will not be redacted through tags.

/cc @zendesk/sustaining @ggrossman 

### Risks
- Low: Credit card numbers separated by angle brackets `<` or `>` are not redacted
