### PR TITLE
Force utf-8 encoding before scrubbing

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -60,6 +60,7 @@ class CreditCardSanitizer
   # Returns a String of the redacted text if a credit card number was detected.
   # Returns nil if no credit card numbers were detected.
   def sanitize!(text)
+    text.force_encoding(Encoding::UTF_8)
     text.scrub!('�')
 
     redacted = nil

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -66,6 +66,11 @@ class CreditCardSanitizerTest < MiniTest::Test
         end
       end
 
+      it "doesn't fail if text is not utf-8 encoded" do
+        ascii_text = '41111111111111112'.force_encoding(Encoding::ASCII)
+        assert_nil @sanitizer.sanitize!(ascii_text)
+      end
+
       it "sanitizes credit card numbers separated by newlines" do
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 \n 4111 11▇▇ ▇▇▇▇ 1111", @sanitizer.sanitize!("4111 1111 1111 1111 \n 4111 1111 1111 1111")
       end


### PR DESCRIPTION
Fixes the encoding issues introduced by #23 

/cc @fneves @ggrossman @grosser