### PR TITLE
Examine card number groupings as a means of preventing false positives.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: ""
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1.7
+  - 2.2.4

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not s
 
 ### Configuration
 
-`replacement_token`: The character used to replace digits of the credit number.  The default is `▇`.
-`expose_first`: The number of leading digits of the credit card number to leave intact. The default is `6`.
-`expose_last`: The number of trailing digits of the credit card number to leave intact. The default is `4`.
-`use_groupings`: Use known card number groupings to reduce false positives. The default is `false`.
+Name                | Description
+------------------- | -----------
+`replacement_token` | The character used to replace digits of the credit number.  The default is `▇`.
+`expose_first`      | The number of leading digits of the credit card number to leave intact. The default is `6`.
+`expose_last`       | The number of trailing digits of the credit card number to leave intact. The default is `4`.
+`use_groupings`     | Use known card number groupings to reduce false positives. The default is `false`.
 
 ### Default Replacement Level
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ number is stored in multiple places on your systems, it can be hard to get rid o
 Removal of credit card information is an important element in [PCI compliance](https://www.pcisecuritystandards.org).
 
 `credit_card_sanitizer` scans text for credit card numbers by applying the Luhn checksum algorithm,
-implemented by the [luhn_checksum](https://github.com/eac/luhn_checksum) gem, and by validating the number has a proper
-credit card number prefix. Numbers in text that appear to be valid credit card numbers are "sanitized" by replacing
-some or all of the digits with a replacement character.
+implemented by the [luhn_checksum](https://github.com/zendesk/luhn_checksum) gem, and by validating that the
+number matches a known credit card number pattern. Numbers in text that appear to be valid credit card numbers
+are "sanitized" by replacing some or all of the digits with a replacement character.
 
 Example:
 
-```Ruby
+```ruby
 text = "Hello my card is 4111 1111 1111 1111  maybe you should not store that in your database!"
 CreditCardSanitizer.new(replacement_character: '▇').sanitizer.sanitize!(text)
 text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not store that in your database!"
@@ -28,6 +28,7 @@ text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not s
 `replacement_token`: The character used to replace digits of the credit number.  The default is `▇`.
 `expose_first`: The number of leading digits of the credit card number to leave intact. The default is `6`.
 `expose_last`: The number of trailing digits of the credit card number to leave intact. The default is `4`.
+`use_groupings`: Use known card number groupings to reduce false positives. The default is `false`.
 
 ### Default Replacement Level
 
@@ -40,7 +41,7 @@ is no longer considered credit card data under the PCI standard.
 ### Line noise
 
 `credit_card_sanitizer` allows for "line noise" between the digits of a credit card number.  Line noise
-is any sequence of non-numeric characters. For example, all of the following numbers will be sanitized
+is a sequence of non-numeric characters. For example, all of the following numbers will be sanitized
 successfully:
 
 ```
@@ -49,12 +50,33 @@ successfully:
 4111*1111***1111*****1111
 ```
 
+We occasionally tweak the regular expression that defines line noise to reduce the rate of false positives.
+
 ### Card number length and valid prefixes
 
 Numbers are sanitized if they are a minimum of 12 digits long and a maximum of 19 digits long, and have a proper
 prefix that matches an IIN range of an issuing network like Visa or MasterCard
-(https://en.wikipedia.org/wiki/Primary_Account_Number). We have shamelessly taken the regex used in [active_merchant](https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18)
+(https://en.wikipedia.org/wiki/Primary_Account_Number). We have borrowed the regex used in [active_merchant](https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18)
 to validate these prefixes.
+
+### Card number groupings
+
+Some false positives are inevitable when using this gem, and they can be a nuisance.
+
+To reduce the false positive rate, you can specify `use_groupings: true` when configuring the sanitizer. This causes
+the sanitizer to pay attention to the groupings of numbers as it scans them, only sanitizing numbers that
+
+* have a valid Luhn checksum
+* match a pattern for a known credit card type
+* are either a single contiguous string of digits, or digits in groups matching that known credit card type
+
+Example: Visa cards are 4 groups of 4 digits, `XXXX XXXX XXXX XXXX`. `4111 1111 1111 1111` is a number that matches
+the Visa pattern (starts with `4`) and passes Luhn checksum.
+
+With `use_groupings: true`, the sanitizer would sanitize `4111111111111111` and `4111 1111 1111 1111` but not
+`41 11 11 11 11 11 11 11` or `41111111 11111111`.
+
+With `use_groupings: false`, the sanitizer would sanitize all of the above strings.
 
 ### Rails filtering parameters
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -21,9 +21,27 @@ class CreditCardSanitizer
     'forbrugsforeningen' => /^600722\d{10}$/,
     'laser'              => /^(6304|6706|6709|6771(?!89))\d{8}(\d{4}|\d{6,7})?$/
   }
+
+  CARD_NUMBER_GROUPINGS = {
+    'visa'               => [[4, 4, 4, 4]],
+    'master'             => [[4, 4, 4, 4]],
+    'discover'           => [[4, 4, 4, 4]],
+    'american_express'   => [[4, 6, 5]],
+    'diners_club'        => [[4, 6, 4]],
+    'jcb'                => [[4, 4, 4, 4]],
+    'switch'             => [[4, 4, 4, 4]],
+    'solo'               => [[4, 4, 4, 4]],
+    'dankort'            => [[4, 4, 4, 4]],
+    'maestro'            => [[4], [5]],
+    'forbrugsforeningen' => [[4, 4, 4, 4]],
+    'laser'              => [[4, 4, 4, 4]]
+  }
+
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:;<>]{,5}/
+  LINE_NOISE_CHAR = /[^\w_\n,()\/:;<>]/
+  LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
+  NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
@@ -68,14 +86,16 @@ class CreditCardSanitizer
     without_expiration(text) do
       text.gsub!(NUMBERS_WITH_LINE_NOISE) do |match|
         next match if $1
+
+        @match = match
         @numbers = match.tr('^0-9', '')
 
         if valid_numbers?
           redacted = true
-          redact_numbers!(match)
+          redact_numbers!
         end
 
-        match
+        @match
       end
     end
 
@@ -109,12 +129,31 @@ class CreditCardSanitizer
     !!(numbers =~ VALID_COMPANY_PREFIXES)
   end
 
-  def valid_numbers?
-    LuhnChecksum.valid?(@numbers) && valid_prefix?(@numbers)
+  def find_company
+    CARD_COMPANIES.each do |company, pattern|
+      return company if @numbers =~ pattern
+    end
   end
 
-  def redact_numbers!(text)
-    text.gsub!(/\d/).with_index do |number, digit_index|
+  def valid_grouping?
+    if company = find_company
+      groupings = @match.split(NONEMPTY_LINE_NOISE).map(&:length)
+      return true if groupings.length == 1
+      if company_groupings = CARD_NUMBER_GROUPINGS[company]
+        company_groupings.each do |company_grouping|
+          return true if groupings.take(company_grouping.length) == company_grouping
+        end
+      end
+    end
+    false
+  end
+
+  def valid_numbers?
+    LuhnChecksum.valid?(@numbers) && valid_prefix?(@numbers) && valid_grouping?
+  end
+
+  def redact_numbers!
+    @match.gsub!(/\d/).with_index do |number, digit_index|
       if within_redaction_range?(digit_index)
         replacement_token
       else

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -51,11 +51,11 @@ class CreditCardSanitizerTest < MiniTest::Test
       end
 
       it "has configurable replacement digits" do
-        @sanitizer = CreditCardSanitizer.new(expose_first: 0, expose_last: 4)
-        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 there',     @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
-        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 z 3 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 z 3 there')
-        assert_equal 'Hello ▇▇▇▇-▇▇▇▇-▇▇▇▇-1111 there', @sanitizer.sanitize!('Hello 4111-1111-1111-1111 there')
-        assert_equal 'Hello ▇▇▇▇▇▇▇▇▇▇▇▇1111 there', @sanitizer.sanitize!('Hello 4111111111111111 there')
+        sanitizer = CreditCardSanitizer.new(expose_first: 0, expose_last: 4)
+        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 z 3 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 z 3 there')
+        assert_equal 'Hello ▇▇▇▇-▇▇▇▇-▇▇▇▇-1111 there', sanitizer.sanitize!('Hello 4111-1111-1111-1111 there')
+        assert_equal 'Hello ▇▇▇▇▇▇▇▇▇▇▇▇1111 there', sanitizer.sanitize!('Hello 4111111111111111 there')
       end
 
       it "does not sanitize invalid credit card numbers" do
@@ -153,47 +153,68 @@ class CreditCardSanitizerTest < MiniTest::Test
       end
 
       describe "card number grouping" do
-        it "sanitizes visa card grouped 4-4-4-4" do
-          assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        describe "use_groupings is false" do
+          before do
+            refute @sanitizer.use_groupings
+          end
+
+          it "sanitizes cards grouped any which way" do
+            assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+            assert_equal 'Hello 41 11 11 ▇▇ ▇▇ ▇▇ 11 11 there', @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
+            assert_equal 'Hello 411111▇▇▇▇▇▇1111 there', @sanitizer.sanitize!('Hello 4111111111111111 there')
+            assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
+            assert_equal 'Hello 378282▇▇▇▇▇0005 there', @sanitizer.sanitize!('Hello 378282246310005 there')
+            assert_equal 'Hello 37 828 2▇▇▇▇▇0 005 there', @sanitizer.sanitize!('Hello 37 828 2246310 005 there')
+          end
         end
 
-        it "does not sanitize visa card grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
-        end
+        describe "use_groupings is true" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(use_groupings: true)
+          end
 
-        it "sanitizes mastercard grouped 4-4-4-4" do
-          assert_equal 'Hello 5555 55▇▇ ▇▇▇▇ 4444 there', @sanitizer.sanitize!('Hello 5555 5555 5555 4444 there')
-        end
+          it "sanitizes visa card grouped 4-4-4-4" do
+            assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+          end
 
-        it "does not sanitize mastercard grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 55555 55555 554444 there')
-        end
+          it "does not sanitize visa card grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
+          end
 
-        it "sanitizes amex card grouped 4-6-5" do
-          assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
-        end
+          it "sanitizes mastercard grouped 4-4-4-4" do
+            assert_equal 'Hello 5555 55▇▇ ▇▇▇▇ 4444 there', @sanitizer.sanitize!('Hello 5555 5555 5555 4444 there')
+          end
 
-        it "does not sanitize amex card grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 3782 8224 6310 005 there')
-        end
+          it "does not sanitize mastercard grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 55555 55555 554444 there')
+          end
 
-        it "sanitizes diners club grouped 4-6-4" do
-          assert_equal 'Hello 3056 93▇▇▇▇ 5904 there', @sanitizer.sanitize!('Hello 3056 930902 5904 there')
-        end
+          it "sanitizes amex card grouped 4-6-5" do
+            assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
+          end
 
-        it "does not sanitize diners club grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 3056 9309 0259 04 there')
-        end
+          it "does not sanitize amex card grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 3782 8224 6310 005 there')
+          end
 
-        it "sanitizes maestro if first group is 4 or 5 digits" do
-          assert_equal 'Hello 6799 99▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 6799 9901000 00000 019 there')
-          assert_equal 'Hello 67999 9▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 67999 901000 00000 019 there')
-        end
+          it "sanitizes diners club grouped 4-6-4" do
+            assert_equal 'Hello 3056 93▇▇▇▇ 5904 there', @sanitizer.sanitize!('Hello 3056 930902 5904 there')
+          end
 
-        it "does not sanitize maestro if first group is not 4 or 5 digits" do
-          assert_nil @sanitizer.sanitize!('Hello 679 99901000 00000 019 there')
-          assert_nil @sanitizer.sanitize!('Hello 67 999901000 00000 019 there')
-          assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
+          it "does not sanitize diners club grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 3056 9309 0259 04 there')
+          end
+
+          it "sanitizes maestro if first group is 4 or 5 digits" do
+            assert_equal 'Hello 6799 99▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 6799 9901000 00000 019 there')
+            assert_equal 'Hello 67999 9▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 67999 901000 00000 019 there')
+          end
+
+          it "does not sanitize maestro if first group is not 4 or 5 digits" do
+            assert_nil @sanitizer.sanitize!('Hello 679 99901000 00000 019 there')
+            assert_nil @sanitizer.sanitize!('Hello 67 999901000 00000 019 there')
+            assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
+          end
         end
       end
     end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -7,6 +7,14 @@ class CreditCardSanitizerTest < MiniTest::Test
       @sanitizer = CreditCardSanitizer.new
     end
 
+    describe "credit card patterns" do
+      it "CARD_NUMBER_GROUPINGS matches CARD_COMPANIES" do
+        a = CreditCardSanitizer::CARD_COMPANIES.keys
+        b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
+        assert_equal [], (a - b) | (b - a)
+      end
+    end
+
     describe "#sanitize!" do
       it "sanitizes text keeping first 6 and last 4 digits by default" do
         assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there',     @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')


### PR DESCRIPTION
Even with known credit card patterns and Luhn checksum, credit_card_sanitizer still sometimes has false positives and ends up redacting text that should not be redacted.

This PR improves the algorithm by having it pay attention to the groupings of a candidate card number.

Premise:
* A Visa card that appears in 4 groups of 4 digits e.g. 4111 1111 1111 1111 was probably a credit card number.
* A Visa card that appears as a single block of 16 digits, 4111111111111111, we can't tell and must treat it as a credit card number.
* But if a Visa card appears in a strange grouping such as 41 11 11 11 11 11 11 11, it probably is NOT a credit card number and we should avoid redacting it.

The table `CARD_NUMBER_GROUPINGS` contains a table of common groupings for the various card types supported.

We check that one of our specified groupings is a prefix for the actual grouping. So, a Visa card might appear with 3 additional digits in a group after the first four groups (e.g. 19 digit PAN in the UK), and that will still be a positive for redaction.

Maestro, in particular, is hard because there seem to be many groupings possible. In that case, we mostly give up and just try to ensure that the first group contains either 4 or 5 digits.

References: zd1113270

@jcheatham @ckumar1 @grosser @kintner @jespr @scott-reed @cericksen 