### PR TITLE
Make it possible to change the configuration on a per-call basis

### DIFF
--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizerTest < MiniTest::Test
     end
 
     describe "credit card patterns" do
-      it "match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
+      it "should match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
         a = CreditCardSanitizer::CARD_COMPANIES.keys
         b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
         assert_equal [], (a - b) | (b - a)

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizerTest < MiniTest::Test
     end
 
     describe "credit card patterns" do
-      it "CARD_NUMBER_GROUPINGS matches CARD_COMPANIES" do
+      it "match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
         a = CreditCardSanitizer::CARD_COMPANIES.keys
         b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
         assert_equal [], (a - b) | (b - a)
@@ -48,6 +48,10 @@ class CreditCardSanitizerTest < MiniTest::Test
       it "has a configurable replacement character" do
         sanitizer = CreditCardSanitizer.new(replacement_token: '*')
         assert_equal 'Hello 4111 11** **** 1111 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+      end
+
+      it "can configure replacement character on a per-call basis" do
+        assert_equal 'Hello 4111 11** **** 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there', replacement_token: '*')
       end
 
       it "has configurable replacement digits" do
@@ -155,7 +159,7 @@ class CreditCardSanitizerTest < MiniTest::Test
       describe "card number grouping" do
         describe "use_groupings is false" do
           before do
-            refute @sanitizer.use_groupings
+            refute @sanitizer.settings[:use_groupings]
           end
 
           it "sanitizes cards grouped any which way" do


### PR DESCRIPTION
This moves the various settings (`replacement_token`, `expose_first`, etc.) into a settings hash, which can be passed in at `CreditCardSanitizer` construction time, but also can be passed on a per-call basis much like `Prop.throttle` in the [prop gem](https://github.com/zendesk/prop).

This will make it easier to turn settings on/off using, say, Arturo without having to construct a whole new `CreditCardSanitizer` object. Until now, the only way to alter the configuration of a `CreditCardSanitizer` was to make a new one.

Also: It's bugged me that the sanitizer is not thread-safe since it uses member variables like `@numbers` in the course of sanitization, so I changed it to use a `Candidate` class holding the original text and the string of digits. Probably a slight performance and memory impact, but I think negligible compared to the amount of regex-foo this gem does.

This is a mildly breaking API change, since the accessors such as `replacement_token` are removed.

/cc @grosser @kintner @jespr @jcheatham 
