### PR TITLE
Fixed bug when preceding html style attr has colon

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -42,7 +42,7 @@ class CreditCardSanitizer
   LINE_NOISE_CHAR = /[^\w_\n,()\/:;<>]/
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
-  SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):[^\s>]+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   DEFAULT_OPTIONS = {

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -87,6 +87,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 \n 4111 11▇▇ ▇▇▇▇ 1111", @sanitizer.sanitize!("4111 1111 1111 1111 \n 4111 1111 1111 1111")
       end
 
+      it "sanitizes credit card numbers that are preceded by html tag containing colon" do
+        assert_equal '<span style="display:none;">411111▇▇▇▇▇▇1111</span>', @sanitizer.sanitize!('<span style="display:none;">4111111111111111</span>')
+      end
+
       it "does not sanitize a credit card number separated by newlines" do
         assert_nil @sanitizer.sanitize!("4111\n1111\n1111\n1111")
       end


### PR DESCRIPTION
When sanitising HTML where the tag preceding a valid card number has an attribute such as a style attribute which contains a colon character, the card number is not sanitised. I have made a small change to the scheme regex to resolve this and have created a corresponding new test.

Feedback welcome.