### PR TITLE
Removes period (.) as a valid line noise character.

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -39,7 +39,7 @@ class CreditCardSanitizer
 
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE_CHAR = /[^\w_\n,()\/:;<>]/
+  LINE_NOISE_CHAR = /[^\w_\n,().\/:;<>]/
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -95,6 +95,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("4111,1111,1111,1111")
       end
 
+      it "does not sanitize a credit card number separated by periods" do
+        assert_nil @sanitizer.sanitize!("4111.1111.1111.1111")
+      end
+
       it "does not sanitize credit card numbers separated by parentheses" do
         assert_nil @sanitizer.sanitize!("(411)111-111111-1111")
       end


### PR DESCRIPTION
We have encountered instances of a number followed by whitespace followed by an IP address getting redacted, i.e. something of the form

4111 111.111.111.111

We believe that it is highly unusual for a credit card number to be separated by periods.

As such, to fix the above problem, we are removing . from the pattern for acceptable line noise between credit card digits.

/cc @kintner @jespr