### PR TITLE
Don't redact credit card number candidates that are valid shipping tracking numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
       thor (>= 0.14.0)
     bump (0.5.0)
     luhn_checksum (0.1.1)
+    luhnacy (0.2.1)
     minitest (5.2.0)
     minitest-rg (5.1.0)
       minitest (~> 5.0)
@@ -31,6 +32,7 @@ DEPENDENCIES
   bump
   bundler
   credit_card_sanitizer!
+  luhnacy
   minitest
   minitest-rg
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     credit_card_sanitizer (0.5.2)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
+      tracking_number (~> 0.10.2)
 
 GEM
   remote: https://rubygems.org/
@@ -20,6 +21,7 @@ GEM
     rake (10.3.1)
     scrub_rb (1.0.1)
     thor (0.19.1)
+    tracking_number (0.10.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not s
 
 ### Configuration
 
-Name                | Description
-------------------- | -----------
-`replacement_token` | The character used to replace digits of the credit number.  The default is `▇`.
-`expose_first`      | The number of leading digits of the credit card number to leave intact. The default is `6`.
-`expose_last`       | The number of trailing digits of the credit card number to leave intact. The default is `4`.
-`use_groupings`     | Use known card number groupings to reduce false positives. The default is `false`.
+Name                       | Description
+-------------------------- | -----------
+`replacement_token`        | The character used to replace digits of the credit number.  The default is `▇`.
+`expose_first`             | The number of leading digits of the credit card number to leave intact. The default is `6`.
+`expose_last`              | The number of trailing digits of the credit card number to leave intact. The default is `4`.
+`use_groupings`            | Use known card number groupings to reduce false positives. The default is `false`.
+`exclude_tracking_numbers` | Identify shipping tracking numbers and don't redact them. The default is `false`.
 
 ### Default Replacement Level
 
@@ -79,6 +80,18 @@ With `use_groupings: true`, the sanitizer would sanitize `4111111111111111` and 
 `41 11 11 11 11 11 11 11` or `41111111 11111111`.
 
 With `use_groupings: false`, the sanitizer would sanitize all of the above strings.
+
+### Exclude Tracking Numbers
+
+Occasionally, a number will match a known credit card pattern and pass Luhn checksum, but will actually
+be a shipping company tracking number, such as a FedEx tracking number.
+
+The `exclude_tracking_numbers` option runs candidate numbers about to be redacted through the
+[tracking_number gem](https://github.com/jkeen/tracking_number) by Jeff Keen.
+
+Turning on this option reduces the likelihood of a tracking number being identified as a false positive
+and redacted. However, it runs the risk of an actual credit card number being incorrectly identified as
+a shipping tracking number, and not redacted.
 
 ### Rails filtering parameters
 

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new 'credit_card_sanitizer', '0.5.2' do |gem|
   gem.add_development_dependency('appraisal')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('bundler')
+  gem.add_development_dependency('luhnacy')
   gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
   gem.add_runtime_dependency('tracking_number', '~> 0.10.2')
   gem.add_runtime_dependency('scrub_rb', '~> 1.0.1')

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -10,5 +10,6 @@ Gem::Specification.new 'credit_card_sanitizer', '0.5.2' do |gem|
   gem.add_development_dependency('rake')
   gem.add_development_dependency('bundler')
   gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
+  gem.add_runtime_dependency('tracking_number', '~> 0.10.2')
   gem.add_runtime_dependency('scrub_rb', '~> 1.0.1')
 end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -205,7 +205,7 @@ class CreditCardSanitizerTest < MiniTest::Test
 
           it "does not sanitize credit card numbers which also may be tracking numbers" do
             @fedex_ccs.each do |candidate|
-              assert_equal nil, @sanitizer.sanitize!(candidate)
+              assert_nil @sanitizer.sanitize!(candidate)
             end
           end
 
@@ -407,7 +407,7 @@ class CreditCardSanitizerTest < MiniTest::Test
       end
       check = total % 10
       check = (10 - check) unless check.zero?
-      (digits + [check]).join.to_s
+      (digits + [check]).join
     end
 
     # Generate "count" random FedEx tracking numbers that definitely pass

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -164,6 +164,33 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("411111111111111123456789")
       end
 
+      describe "exclude tracking numbers" do
+        describe "exclude_tracking_numbers is false" do
+          before do
+            refute @sanitizer.settings[:exclude_tracking_numbers]
+          end
+
+          it "sanitizes credit card numbers which also may be tracking numbers" do
+            # 8/30/16 - These FedEx tracking numbers were randomly generated and do not correspond to actual packages.
+            assert_equal "674571▇▇▇▇▇0139", @sanitizer.sanitize!("674571471090139")
+            assert_equal "630052▇▇▇▇▇9718", @sanitizer.sanitize!("630052240299718")
+            assert_equal "662179▇▇▇▇▇0935", @sanitizer.sanitize!("662179177810935")
+          end
+        end
+
+        describe "exclude_tracking_numbers is true" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(exclude_tracking_numbers: true)
+          end
+
+          it "does not sanitize credit card numbers which also may be tracking numbers" do
+            assert_equal nil, @sanitizer.sanitize!("674571471090139")
+            assert_equal nil, @sanitizer.sanitize!("630052240299718")
+            assert_equal nil, @sanitizer.sanitize!("662179177810935")
+          end
+        end
+      end
+
       describe "card number grouping" do
         describe "use_groupings is false" do
           before do

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require File.expand_path '../helper', __FILE__
+require 'luhnacy'
 
 class CreditCardSanitizerTest < MiniTest::Test
   describe CreditCardSanitizer do
@@ -27,6 +28,22 @@ class CreditCardSanitizerTest < MiniTest::Test
         path = File.expand_path('../samples/japanese_text.txt', __FILE__)
         text = File.open(path).read
         @sanitizer.sanitize!(text)
+      end
+
+      it "sanitizes lots of random Visa cards" do
+        10000.times do
+          candidate = Luhnacy.generate(16, prefix: '4')
+          assert_equal candidate[0..5]+'▇▇▇▇▇▇'+candidate[12..-1], @sanitizer.sanitize!(candidate)
+        end
+      end
+
+      it "sanitizes lots of random MasterCard cards" do
+        ['51', '52', '53', '54', '55', '677189'].each do |prefix|
+          10000.times do
+            candidate = Luhnacy.generate(16, prefix: prefix)
+            assert_equal candidate[0..5]+'▇▇▇▇▇▇'+candidate[12..-1], @sanitizer.sanitize!(candidate)
+          end
+        end
       end
 
       it "sanitizes text with other numbers in it" do
@@ -189,6 +206,22 @@ class CreditCardSanitizerTest < MiniTest::Test
           it "does not sanitize credit card numbers which also may be tracking numbers" do
             @fedex_ccs.each do |candidate|
               assert_equal nil, @sanitizer.sanitize!(candidate)
+            end
+          end
+
+          it "still sanitizes lots of random Visa cards" do
+            10000.times do
+              candidate = Luhnacy.generate(16, prefix: '4')
+              assert_equal candidate[0..5]+'▇▇▇▇▇▇'+candidate[12..-1], @sanitizer.sanitize!(candidate)
+            end
+          end
+
+          it "still sanitizes lots of random MasterCard cards" do
+            ['51', '52', '53', '54', '55', '677189'].each do |prefix|
+              10000.times do
+                candidate = Luhnacy.generate(16, prefix: prefix)
+                assert_equal candidate[0..5]+'▇▇▇▇▇▇'+candidate[12..-1], @sanitizer.sanitize!(candidate)
+              end
             end
           end
         end


### PR DESCRIPTION
The credit card sanitizer sometimes redacts shipping company tracking numbers, such as FedEx tracking numbers, as false positives for credit card numbers. If this happens, it can be a nuisance for customers who needed a tracking number out of a message but now find it blacked out.

This adds an option `exclude_tracking_numbers` to the sanitizer. If this option is on, a candidate number that is about to be redacted will be run through the [tracking_number](https://github.com/jkeen/tracking_number) gem to determine if it's a valid tracking number for some shipper. If it is, the number won't be redacted.

One of the challenges with this change was creating a test. We didn't want to use real FedEx tracking numbers. So, we generate random 15-digit numbers with a valid FedEx check digit and, by brute force, keep generating these until we have a bunch that also pass Luhn checksum.

@jespr @kintner 