### PR TITLE
don't redact a UPS tracking number

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -44,7 +44,8 @@ class CreditCardSanitizer
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):[^\s>]+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
+  PARTIAL_TRACKING = /1z\w+/i
+  NUMBERS_WITH_LINE_NOISE = /#{PARTIAL_TRACKING}?#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   DEFAULT_OPTIONS = {
     replacement_token: '▇',
@@ -165,7 +166,7 @@ class CreditCardSanitizer
   end
 
   def is_tracking?(candidate, options)
-    options[:exclude_tracking_numbers] && TrackingNumber.new(candidate.numbers).valid?
+    options[:exclude_tracking_numbers] && TrackingNumber.new(candidate.text).valid?
   end
 
   def valid_numbers?(candidate, options)

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -209,6 +209,10 @@ class CreditCardSanitizerTest < MiniTest::Test
             end
           end
 
+          it "does not sanitize a ups tracking number" do
+            assert_nil @sanitizer.sanitize!('1Z180E660391202208')
+          end
+
           it "still sanitizes lots of random Visa cards" do
             10000.times do
               candidate = Luhnacy.generate(16, prefix: '4')


### PR DESCRIPTION
@ggrossman @jespr 

A UPS tracking number is prefixed with an `1z` and an alphanumeric string which currently is not matched by the regex. 

Therefore we detect a embded Maestro number in 1Z180E`660391202208` and redact that. 

Is there a better option then just adding `1z` to the regex like we do for scheme? 