### PR TITLE
[SECDEV-1327] Fix two bugs numbers that contain & or a valid credit card number plus additional numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       rake
       thor (>= 0.14.0)
     bump (0.5.0)
+    byebug (9.0.6)
     luhn_checksum (0.1.1)
     luhnacy (0.2.1)
     minitest (5.2.0)
@@ -29,6 +30,7 @@ DEPENDENCIES
   appraisal
   bump
   bundler
+  byebug
   credit_card_sanitizer!
   luhnacy
   minitest
@@ -36,4 +38,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.13.6
+   1.14.2

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new 'credit_card_sanitizer', '0.6.0' do |gem|
   gem.add_development_dependency('rake')
   gem.add_development_dependency('bundler')
   gem.add_development_dependency('luhnacy')
+  gem.add_development_dependency('byebug')
   gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
   gem.add_runtime_dependency('tracking_number', '~> 0.10.2')
 end

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -39,11 +39,11 @@ class CreditCardSanitizer
 
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE_CHAR = /[^\w_\n,().\/:;<>]/
+  LINE_NOISE_CHAR = /[^\w\n,()&.\/:;<>]/
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):[^\s>]+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,30}/
 
   DEFAULT_OPTIONS = {
     replacement_token: '▇',
@@ -94,7 +94,6 @@ class CreditCardSanitizer
     text.scrub!('�')
 
     redacted = nil
-
     without_expiration(text) do
       text.gsub!(NUMBERS_WITH_LINE_NOISE) do |match|
         next match if $1

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -160,6 +160,14 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "http://support.zendesk.com/tickets/4111111111111111", url
       end
 
+      it "does not sanitize groups of numbers with & in them such as shipping numbers" do
+        assert_nil @sanitizer.sanitize!("Hello 4111 1111&1111 1111 there")
+      end
+
+      it "does not sanitize a valid credit card number followed by additional numbers that invalidate the credit card number" do
+        assert_nil @sanitizer.sanitize!("612999921404471347800000")
+      end
+
       it "should sanitize a credit card number with an expiration date" do
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03/2015", @sanitizer.sanitize!("4111 1111 1111 1111 03/2015")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03/15", @sanitizer.sanitize!("4111 1111 1111 1111 03/15")
@@ -174,11 +182,6 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 3-15", @sanitizer.sanitize!("4111 1111 1111 1111 3-15")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 3-2015", @sanitizer.sanitize!("4111 1111 1111 1111 3-2015")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03-2015 asdbhasd", @sanitizer.sanitize!("4111 1111 1111 1111 03-2015 asdbhasd")
-      end
-
-      it "does not sanitize a credit card number immediately followed by digits" do
-        assert_nil @sanitizer.sanitize!("41111111111111112")
-        assert_nil @sanitizer.sanitize!("411111111111111123456789")
       end
 
       describe "exclude tracking numbers" do


### PR DESCRIPTION
/cc @zendesk/secdev @ggrossman 

### Description
Bug 1: A long UPS number that starts with a valid credit card number that is 18 digits long
Fix: Increase the length of the match so that it will pick up numbers that will then fail the credit card specific checks.

Bug 2: A Shipping number that contains an & sign
Fix: And the & sign to the not allowed list.

### Risks
* [low] small changes to avoid two specific edge cases
