### PR TITLE
[SECDEV-1579] add an option to exclude_html_tags from redaction

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
+  t.warning = false
 end
 
 task :default => :test

--- a/test/samples/html_example.html
+++ b/test/samples/html_example.html
@@ -1,0 +1,672 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js no-pass-type ie6 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js no-pass-type ie7 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js no-pass-type ie8 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 9]>    <html class="no-js no-pass-type ie9" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" prefix="og: http://ogp.me/ns#"> <!--<![endif]-->
+<head>
+<title>Zendesk | Customer Service Software &amp; Support Ticket System</title>
+<script>
+    // Create ga object before optimizely loads, since the snippet for
+    // analytics.js is being loaded async through GTM
+    window.ga = window.ga || function() {
+      (window.ga.q = window.ga.q || []).push(arguments)
+    };
+  </script>
+<script src="//cdn.optimizely.com/js/112699136.js"></script>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta charset="UTF-8"/>
+<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<meta name="google-site-verification" content="2q8u-0_6HxJZdS7l7LYlf-WDEYwIPvdJ_XVujkTFNCY"/>
+<meta name="viewport" content="width=device-width">
+<!--[if lt IE 9]>
+      <script src="//d26a57ydsghvgx.cloudfront.net/www/public/assets/js/css3-mediaqueries.js"></script>
+    <![endif]-->
+<link rel="profile" href="https://gmpg.org/xfn/11"/>
+<link rel="dns-prefetch" href="//d16cvnquvjw7pr.cloudfront.net">
+<link rel="dns-prefetch" href="//ajax.googleapis.com">
+<link rel="shortcut icon" href="//d1eipm3vz40hy0.cloudfront.net/images/logos/zendesk-favicon.ico"/>
+
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk144.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk114.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk72.png">
+
+<link rel="apple-touch-icon-precomposed" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk57.png">
+<meta property="og:image" content="https://d16cvnquvjw7pr.cloudfront.net/images/blog/zendesk-default-placeholder.jpg"/>
+<meta category="og:category" content=""/>
+<meta name="description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<link rel="canonical" href="https://www.zendesk.com"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="article"/>
+<meta property="og:title" content="Zendesk | Customer Service Software &amp; Support Ticket System"/>
+<meta property="og:description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<meta property="og:url" content="https://www.zendesk.com"/>
+<meta property="og:site_name" content="Zendesk"/>
+<link href="https://d1eipm3vz40hy0.cloudfront.net/css/screen.min.e20e646a.css" media="all" rel="stylesheet" type="text/css"/></head>
+<body data-useragent class="lang-en responsive " lang="en-US">
+<script type="text/javascript">
+  window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+  heap.load("1646711747");
+</script>
+<script type="text/javascript">
+  (function() {
+    var loadConvertro = function() {
+      (function(c){var e=document.createElement("script");
+      e.type='text/javascript';e.async=true;
+      e.src='//d1ivexoxmp59q7.cloudfront.net/'+c+'/live.js';
+      var n=document.getElementsByTagName('script')[0];
+      n.parentNode.insertBefore(e,n);})('zendesk');
+    };
+
+    if (!window.potentialBot) {
+      loadConvertro();
+    }
+  }());
+</script>
+<header class="masthead-refresh  " role="banner">
+<div class="masthead-top">
+<div class="secondary-menu menu">
+<a class="secondary-menu-item" href="/login/">Log In</a>
+<a class="secondary-menu-item" href="//help.zendesk.com/">Product Support</a>
+<ul class="secondary-menu-item company">
+<li class="first">
+<a href="#">Company<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="/about/">About us</a></li>
+<li class="list-item"><a href="/company/press/">Press</a></li>
+<li class="list-item SL_norewrite"><a href="//investor.zendesk.com/">Investors</a></li>
+<li class="list-item SL_norewrite"><a href="/company/events/">Events</a></li>
+<li class="list-item"><a href="/jobs/">Careers</a></li>
+<li class="list-item"><a href="/company/contact-info/">Legal</a></li>
+</ul>
+</li>
+</ul>
+<a class="secondary-menu-item" href="/support/contact/">Contact Us</a>
+<ul class="list list-vert SL_swap secondary-menu-item masthead-top-item masthead-top-i18n" id="smartling-lang-dropdown">
+<li class="first"><a href="#">English<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="https://www.zendesk.co.uk">English (UK)</a></li>
+<li class="list-item"><a href="https://www.zendesk.es">Español</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.mx">Español (LATAM)</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.br">Português</a></li>
+<li class="list-item"><a href="https://www.zendesk.fr">Français</a></li>
+<li class="list-item"><a href="https://www.zendesk.de">Deutsch</a></li>
+<li class="list-item"><a href="https://www.zendesk.it">Italiano</a></li>
+<li class="list-item"><a href="https://www.zendesk.nl">Nederlands</a></li>
+<li class="list-item"><a href="https://www.zendesk.co.jp">日本語</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.ru">Pусский</a></li>
+<li class="list-item"><a href="https://www.zendesk.kr">한국어</a></li>
+</ul>
+</ul>
+</div>
+<div class="masthead-stuck-target">
+<div class="js-stuck-inner">
+<header class="site-title">
+<a href="/" class="zendesk-logo" rel="home"></a>
+</header>
+<div class="primary-menu menu">
+<div class="primary-menu-anchor"></div>
+<nav class="primary-menu-list-wrap">
+<ul id="menu-header-navigation-mini" class="primary-menu-list">
+<li id="smartling-nvg-product" class="SL_swap menu-item list-parent ">
+<a href="/product/tour/" class="menu-heading link-tier-1">Products</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>The Zendesk Family</h2>
+<p>The Zendesk family of products work together to help you improve customer relationships</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/support/">
+<li class="support-product">
+<span class='product-logo'></span>
+<h4>support</h4>
+<p class="product-subheader">Multi-channel customer service</p>
+</li>
+</a>
+<a href="/help-center/">
+<li class="help-product">
+<span class='product-logo'></span>
+<h4>help&nbsp;center</h4>
+<p class="product-subheader">Knowledge base and self-service</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/chat/">
+<li class="chat-product">
+<span class='product-logo'></span>
+<h4>chat</h4>
+<p class="product-subheader">Live chat software</p>
+</li>
+</a>
+<a href="/talk/">
+<li class="talk-product">
+<span class='product-logo'></span>
+<h4>talk</h4>
+<p class="product-subheader">Integrated call center software</p>
+</li>
+</a>
+<a href="/message/">
+<li class="message-product">
+<span class='product-logo'></span>
+<h4>message</h4><span class="new-button">new</span>
+<p class="product-subheader">Social messaging apps</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/explore/">
+<li class="explore-product">
+<span class='product-logo'></span>
+<h4>explore</h4><span class="new-button">new</span>
+<p class="product-subheader">Analytics and reporting</p>
+</li>
+</a>
+<a href="/connect/">
+<li class="connect-product">
+<span class='product-logo'></span>
+<h4>connect</h4><span class="new-button">new</span>
+<p class="product-subheader">Segmentation and targeting</p>
+</li>
+</a>
+<a href="/inbox/">
+<li class="inbox-product">
+<span class='product-logo'></span>
+<h4>inbox</h4>
+<p class="product-subheader">Shared team inbox</p>
+</li>
+</a>
+</ul>
+</div>
+<ul class="bottom-options">
+<li class="title">
+<h3>The flexibility to go even further:</h3>
+</li>
+<li>
+<a href="/apps/"><h3>Zendesk Apps Marketplace</h3></a>
+</li>
+<li>
+<a href="/embeddables/"><h3>Embeddables</h3></a>
+</li>
+</ul>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-pricing" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/product/pricing/">Pricing</a></li>
+<li id="smartling-nvg-demo" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/demo/">Demo</a></li>
+<li id="smartling-nvg-solutions" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/enterprise/">Solutions</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Solutions</h2>
+<p class="solution-subheader">The Zendesk family of products helps improve relationships with customers and employees, for companies big and small</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/enterprise/">
+<li>
+<h5>Customer support for enterprise<h5>
+<p class="solution-subheader">Innovation, security, and integration—at scale</p>
+</li>
+</a>
+<a href="/smb/">
+<li>
+<h5>Support for growing businesses<h5>
+<p class="solution-subheader">Flexibility to start small and grow</p>
+</li></a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/internal-help-desk/">
+<li>
+<h5>Internal service desk for employees<h5>
+<p class="solution-subheader">Service desks for HR, IT, and more </p>
+</li>
+</a>
+<a href="/mobile-solutions/">
+<li>
+<h5>Customer support for mobile<h5>
+<p class="solution-subheader">Engage with customers everywhere</p>
+</li></a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-customers" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/customer-experience/">Services</a></li>
+<li id="smartling-nvg-resources" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/resources/">Resources</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Resources</h2>
+<p>Learn more about Zendesk and how to create a better customer experience</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/resources/">
+<li>
+<h5>Library<h5>
+<p>Guides, research, videos, and resources</p>
+</li>
+</a>
+<a href="/blog/">
+<li>
+<h5>Blog<h5>
+<p>News, tips, and best practices</p>
+</li>
+</a>
+<a href="/why-zendesk/customers/">
+<li>
+<h5>Customer Stories<h5>
+<p>See what success with Zendesk looks like</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/company/events/">
+<li>
+<h5>Events<h5>
+<p>Come meet us in person</p>
+</li>
+</a>
+<a href="/support/webinars/">
+<li>
+<h5>Live Webinars<h5>
+<p>Online events</p>
+</li>
+</a>
+<a href="//relate.zendesk.com/">
+<li>
+<h5>Relate by Zendesk<h5>
+<p>Customers. Colleagues. Community. It&apos;s complicated.</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/partner/">
+<li>
+<h5>Partners<h5>
+<p>How to locate or become a Zendesk partner</p>
+</li>
+</a>
+<a href="//developer.zendesk.com/">
+<li>
+<h5>API &#038; Developers<h5>
+<p>Info for building things with Zendesk</p>
+</li>
+</a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li class="list-parent register-desktop"><a href="/register/" id="nav-get-started"><span class="register">Get started</span></a></li>
+<li class="register-mobile">
+<a id="nav-get-started-mobile" href="/register/">Get started</a>
+</li>
+</ul>
+</nav>
+</div>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</header>
+<article class="home-tour home-golion">
+<span style="position: absolute; z-index: -999;">
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/on-combined-2X.png" alt="" width="0" height="0"/>
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/hover-combined-2X.png" alt="" width="0" height="0"/>
+</span>
+<article class="mod-block hero-background">
+<div class="video-outer-wrapper">
+<div class="video-inner-wrap">
+<video id="hero-video" class="hero-video">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.webm" type="video/webm; codecs=vp8,vorbis">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.mp4" type="video/mp4">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.ogv" type="video/ogg; codecs=theora,vorbis">
+</video>
+</div>
+<div class="video-cta-wrapper SL_swap" id="video_id_reintroducing_zendesk">
+<a href="//fast.wistia.com/embed/iframe/sxpw0wdxff?autoPlay=true&popover=true" class="wistia-popover[height=568,playerColor=7b796a,width=960] video-play-cta">Watch the video</a>
+</div>
+</div>
+<section class="mod-section">
+<div class="content">
+<div class="row the-hero">
+<div class="inner">
+<div class="video-container">
+</div>
+<div class="center">
+<h1>Let&apos;s make things better</h1>
+<div class="sub">Zendesk builds software for better customer relationships</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</article>
+<article class="mod-block zendesk-family">
+<div class="content">
+<section class="mod-section">
+<div class="inner">
+<div class="center relationship-text">
+<p>
+Good relationships take work. They require knowledge and the tools to get the <br class="hide-mobile"> job done right. That&apos;s what Zendesk is for.
+</p>
+<p>
+<span>Our products allow businesses to be more reliable, flexible, and scalable.</span>
+<br>
+<span>They help improve communication and make sense of massive amounts of data.</span>
+<br>
+<span>Above all, they help you turn interactions into lasting relationships.</span>
+</p>
+</div>
+<div class="center zendesk-family-products">
+<ol>
+<li>Redacts a regular credit card 4111111111111111 in text</li>
+<li>Redacts a credit card with spaces 4111 1111 1111 1111 in a line</li>
+<li>Redacts a credit card with dashes 4111-1111-1111-1111 next to words</li>
+<li class="4111111111111111"> does not redact when 4111 1111 1111 1111 card is a class</li>
+<li>41111111111 bottles of beer on the wall is not a credit card number</li>
+<li>VISA example 4111 1111 1111 1111 mastercard 5500 0000 0000 0004</li>
+<li>this is an 3400 0000 0000 009 american express example</li>
+<li>Does not redact if  & inside 4111&111111111111</li>
+<li>你好 4111 1111 1111 1111 there invalid characters</li>
+<li>4111.1111.1111.1111</li>
+<li>(411)1-111-11111-1111</li>
+<li>4111/1111/1111/1111</li>
+<li>4111:1111 1111 1111</li>
+<li>click this link http://support.zendesk.com/tickets/4111111111111111 </li>
+<li>credit card number followed by numbers 612999921404471347800000</li>
+<li>credit card number 6129999214044713478</li>
+<li>card number followed by expiration date 4111 1111 1111 1111 03/17</li>
+</ol>
+<p>
+test 4111 1111 1111 1111 with a new line \n 4111 1111 1111 1111 \n 4111 \n 1111\n 1111\n 1111
+</p>
+http://support.zendesk.com/tickets/4111111111111111
+<a class="4111111111111111" href="http://support.zendesk.com/tickets/4111111111111111">click here</a>
+<a class="product-link" href="/support/">
+<span class="feature-icon-common icon-support"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-support.png" alt="Zendesk Support logo" width="72" height="25"/>
+</a>
+<a href="/help-center/" class="product-link">
+<span class="feature-icon-common icon-help-center"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-help-center.png" alt="Zendesk Help Center logo" width="72" height="25"/>
+</a>
+<a href="/chat/" class="product-link">
+<span class="feature-icon-common icon-chat"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-chat.png" alt="Zendesk Chat logo" width="72" height="25"/>
+</a>
+<a href="/talk/" class="product-link">
+<span class="feature-icon-common icon-talk"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-talk.png" alt="Zendesk Talk logo" width="72" height="25"/>
+</a>
+<a href="/message/" class="product-link">
+<span class="feature-icon-common icon-message"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-message.png" alt="Zendesk Message logo" width="72" height="25"/>
+</a>
+<a href="/connect/" class="product-link">
+<span class="feature-icon-common icon-connect"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-connect.png" alt="Zendesk Connect logo" width="72" height="25"/>
+</a>
+<a href="/explore/" class="product-link">
+<span class="feature-icon-common icon-explore"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-explore.png" alt="Zendesk Explore logo" width="72" height="25"/>
+</a>
+</div>
+<div class="center cta-section">
+<a class="btn btn-content-cta" id="home-whats-new" href="/whats-new/">See what&apos;s new</a>
+<a class="btn btn-conversion-cta" id="home-demo-request" href="/demo/">Request a demo</a>
+</div>
+</div>
+</section>
+</div>
+</article>
+</article>
+<script charset="ISO-8859-1" src="//fast.wistia.net/static/popover-v1.js"></script>
+</div>
+<div class="clearfix"></div>
+<footer class="clear">
+<div class="sitemap mega-footer">
+<div class="col-960">
+<nav class="primary-menu-list-wrap">
+<ul id="menu-footer-navigation" class="primary-menu-list">
+<li id="smartling-nav-footer-product" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/support/">Our Products</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/">Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/">Help Center</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/chat/">Chat</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/talk/">Talk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/message/">Message</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/inbox/">Inbox Team Email</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/explore/">Explore</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/connect/">Connect</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/apps/">Integrations &#038; Apps</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/embeddables/">Embeddables</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/zendesk-insights/">Insights &amp; Analytics</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/whats-new/">Product Updates</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-features" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Top Features</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/features/ticketing-system/">Ticketing System</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/knowledge-base-software/">Knowledge Base</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/community-software/">Community Forums</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/">Help Desk Software</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/internal-help-desk/it-help-desk-software/">IT Help Desk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/zendesk-security/">Security</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/tech-specs/">Tech Specs</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-resources" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/resources/">Resources</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="//support.zendesk.com/hc/en-us/">Product Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/demo/">Request a demo</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/">Library</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_norewrite"><a href="/blog/">Zendesk Blog</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/webinars/">Live webinars</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/training/#training">Training</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://developers.zendesk.com">API &#038; Developers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/partners/">Services &#038; Partners</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/lp/retail/">For Retailers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/">Relate by Zendesk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/why-zendesk/customers/">Customer Stories</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/">Services</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-company" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/about/">Company</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/about/">About us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/company/press/">Press</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://investor.zendesk.com">Investors</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/jobs/">Careers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://www.neighborfoundation.org/">Neighbor Foundation</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/contact/">Contact Us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/sitemap/">Sitemap</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://status.zendesk.com">System Status</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://help.zendesk.com/hc/en-us">Product Help</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-favorites" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Favorite Things</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/startups/">Zendesk for Startups</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://relate.zendesk.com/articles/shit-support-agents-say/">Sh*t Agents Say</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="https://www.youtube.com/watch?v=wPtnoRqQa5U">Zoe Calls Home</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/benchmark-your-support/">Zendesk Benchmark</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/small-business/">Zendesk for Small Business</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/gartner-magic-quadrant-crm/">Gartner CRM Magic Quadrant</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/education/interview-questions-hiring-great-customer-service-reps/">Hiring Great Support Teams</a></li>
+</ul>
+</div>
+</li>
+</ul>
+<div style="clear: both;"></div>
+</nav>
+<div id="newsletter-form" class="newsletter-sub">
+<h3>Enter the Fold</h3>
+<p>Join the elite group of other people who have also signed up for our mailing list.</p>
+<form id="newsletter" class="form-gray" method="post" name="eloquaform">
+<label class="success"><span></span>Welcome to the club!</label>
+<ul>
+<li class="error">
+<div class="depth-wrap">
+<input name="owner[email]" id="owner[email]" type="text" placeholder="What&apos;s your email?" class="email">
+<a class="register"></a>
+</div>
+<label style="display: block; opacity: 1;"><span></span>Please use a valid email</label>
+</li>
+<li style="display:none">
+<input type="hidden" name="elqFormName" id="elqFormName" value="WebsiteNewsletterSignup_new">
+</li>
+</ul>
+</form>
+<div class="l-island l-island-right social clear">
+<span itemscope itemtype="https://schema.org/Organization">
+<link itemprop="url" href="https://www.zendesk.com">
+<a itemprop="sameAs" href="//plus.google.com/+zendesk" class="ent-text ico-gplus" rel="publisher">&#59639;</a>
+<a itemprop="sameAs" href="//www.facebook.com/zendesk" class="ent-text ico-facebook">&#59636;</a>
+<a itemprop="sameAs" href="//www.twitter.com/zendesk" class="ent-text ico-twitter">&#59634;</a>
+<a itemprop="sameAs" href="//www.linkedin.com/company/zendesk" class="ent-text ico-linkedin">&#59645;</a>
+<a itemprop="sameAs" href="http://www.slideshare.net/zendesk" class="ent-text ico-slideshare"></a>
+<a itemprop="sameAs" href="//instagram.com/zendesk/" class="ent-text ico-instagram">&#59657;</a>
+</span>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</div>
+<div class="legal clear">
+<div class="col-960">
+<a href="//www.zendesk.com/company/customers-partners/#terms-of-use">Terms of Use</a>
+<a href="//www.zendesk.com/company/customers-partners/#privacy-policy">Privacy Policy</a>
+<a href="//www.zendesk.com/company/customers-partners/#cookie-policy">Cookie Policy</a>
+<a href="https://www.zendesk.com/legal/">&copy;Zendesk 2017</a>
+</div>
+</div>
+<div class="universe-search">
+<div class="universe-search-close ent-text"></div>
+<div class="col-960">
+<div class="universe-search-help"><span class="universe-search-help-count">0</span> results. <br/>How about another try?</div>
+<div class="universe-search-form">
+<span class="universe-search-icon ent-text"></span>
+<input type="text" name="search" class="universe-search-input" placeholder="Start typing to get your search on..." value=""/>
+</div>
+<div class="universe-search-results"></div>
+<div class="universe-search-pagination" style="display:none">
+<ol class="universe-search-pagination-list"> </ol>
+</div>
+</div>
+</div>
+<div class="search">
+<div class="col-960">
+<a href="javascript:;" class="search-launcher"><span class="ent-text icon"></span>Search Zendesk <span class="cursor"></span></a>
+</div>
+</div>
+<div class="clearfix"></div>
+</footer>
+
+<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" data-apikey="14b4da2b1698aa9ce8da80a183366f26"></script>
+<script type="text/javascript" src="//api.demandbase.com/api/v2/ip.js?key=cb334198e711721abab9b3d4c785e482544ca07f&var=dbase"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/plugins.min.b8103b49.js"></script><script src="https://d1eipm3vz40hy0.cloudfront.net/js/webutils.min.d107191a.js"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/global.min.04c36daa.js"></script>
+
+<script type="text/javascript">
+  webutils.styleHeader();
+  webutils.gauge();
+
+  var emeaCountryCodes = new Array('UK', 'GB', 'IM', 'GI', 'JE', 'GG', 'AT', 'BE', 'CY', 'EE', 'FI', 'FR', 'DE', 'EL', 'IE', 'IT', 'LV', 'LU', 'MT', 'NL', 'PT', 'SK', 'SI', 'ES', 'MC', 'VA', 'SM', 'ME', 'MC', 'LU', 'XK', 'KV', 'GR', 'AD')
+    , emeaDomainNames  = new Array('www.zendesk.de', 'www.zendesk.es', 'www.zendesk.fr', 'www.zendesk.it', 'www.zendesk.nl');
+
+  if((typeof dbase !== 'undefined' && $.inArray(dbase.registry_country_code, emeaCountryCodes) > -1) || $.inArray(window.location.hostname, emeaDomainNames) > -1) {
+    webutils.cookieNotice();
+  }
+
+  webutils.loadEloqua();
+</script>
+<script type="text/javascript">
+  dataLayer = [];
+</script>
+
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-Z4DV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+<script>
+  if (!window.potentialBot) {
+    webutils.loadGTM();
+    webutils.processGA();
+    webutils.saveEloquaGuid();
+  }
+</script>
+<script type="text/javascript">
+  $(document).ready(function(){
+    webutils.lockTopNavigation(); // make top navigation sticky
+
+    var animationHelpers = {
+      appearDone: function(e) {
+        $(e.currentTarget)
+          .addClass("entrance-done")
+          .off("animationend", animationHelpers.appearDone)
+          .on("animationend", animationHelpers.hoverState);
+        $(e.currentTarget).parent()
+          .on("mouseover", animationHelpers.mouseOver);
+      },
+      hoverState: function(e) {
+        $(e.currentTarget).removeClass("hover");
+      },
+      mouseOver: function(e){
+        $(e.currentTarget).children(".feature-icon-common").addClass("hover");
+      },
+      curtainUp: function(e) {
+        var curtainCall = animationHelpers.$family.offset().top;
+        var windowOffset   = window.pageYOffset + window.innerHeight;
+
+        if (curtainCall < windowOffset) {
+          animationHelpers.$family.addClass("curtain-up");
+          $(window).off("scroll", animationHelpers.curtainUp);
+        }
+      },
+      $family: $(".zendesk-family-products")
+    }
+
+    $(".product-link").children(".feature-icon-common").on("animationend", animationHelpers.appearDone);
+
+    if (!_isMobile) {
+      document.getElementById("hero-video").play();
+    }
+    $(window).scroll(animationHelpers.curtainUp);
+    animationHelpers.curtainUp();
+
+  });
+
+</script>
+</body>
+</html>

--- a/test/samples/html_example_with_html.html
+++ b/test/samples/html_example_with_html.html
@@ -1,0 +1,672 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js no-pass-type ie6 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js no-pass-type ie7 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js no-pass-type ie8 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 9]>    <html class="no-js no-pass-type ie9" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" prefix="og: http://ogp.me/ns#"> <!--<![endif]-->
+<head>
+<title>Zendesk | Customer Service Software &amp; Support Ticket System</title>
+<script>
+    // Create ga object before optimizely loads, since the snippet for
+    // analytics.js is being loaded async through GTM
+    window.ga = window.ga || function() {
+      (window.ga.q = window.ga.q || []).push(arguments)
+    };
+  </script>
+<script src="//cdn.optimizely.com/js/112699136.js"></script>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta charset="UTF-8"/>
+<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<meta name="google-site-verification" content="2q8u-0_6HxJZdS7l7LYlf-WDEYwIPvdJ_XVujkTFNCY"/>
+<meta name="viewport" content="width=device-width">
+<!--[if lt IE 9]>
+      <script src="//d26a57ydsghvgx.cloudfront.net/www/public/assets/js/css3-mediaqueries.js"></script>
+    <![endif]-->
+<link rel="profile" href="https://gmpg.org/xfn/11"/>
+<link rel="dns-prefetch" href="//d16cvnquvjw7pr.cloudfront.net">
+<link rel="dns-prefetch" href="//ajax.googleapis.com">
+<link rel="shortcut icon" href="//d1eipm3vz40hy0.cloudfront.net/images/logos/zendesk-favicon.ico"/>
+
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk144.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk114.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk72.png">
+
+<link rel="apple-touch-icon-precomposed" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk57.png">
+<meta property="og:image" content="https://d16cvnquvjw7pr.cloudfront.net/images/blog/zendesk-default-placeholder.jpg"/>
+<meta category="og:category" content=""/>
+<meta name="description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<link rel="canonical" href="https://www.zendesk.com"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="article"/>
+<meta property="og:title" content="Zendesk | Customer Service Software &amp; Support Ticket System"/>
+<meta property="og:description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<meta property="og:url" content="https://www.zendesk.com"/>
+<meta property="og:site_name" content="Zendesk"/>
+<link href="https://d1eipm3vz40hy0.cloudfront.net/css/screen.min.e20e646a.css" media="all" rel="stylesheet" type="text/css"/></head>
+<body data-useragent class="lang-en responsive " lang="en-US">
+<script type="text/javascript">
+  window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+  heap.load("1646711747");
+</script>
+<script type="text/javascript">
+  (function() {
+    var loadConvertro = function() {
+      (function(c){var e=document.createElement("script");
+      e.type='text/javascript';e.async=true;
+      e.src='//d1ivexoxmp59q7.cloudfront.net/'+c+'/live.js';
+      var n=document.getElementsByTagName('script')[0];
+      n.parentNode.insertBefore(e,n);})('zendesk');
+    };
+
+    if (!window.potentialBot) {
+      loadConvertro();
+    }
+  }());
+</script>
+<header class="masthead-refresh  " role="banner">
+<div class="masthead-top">
+<div class="secondary-menu menu">
+<a class="secondary-menu-item" href="/login/">Log In</a>
+<a class="secondary-menu-item" href="//help.zendesk.com/">Product Support</a>
+<ul class="secondary-menu-item company">
+<li class="first">
+<a href="#">Company<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="/about/">About us</a></li>
+<li class="list-item"><a href="/company/press/">Press</a></li>
+<li class="list-item SL_norewrite"><a href="//investor.zendesk.com/">Investors</a></li>
+<li class="list-item SL_norewrite"><a href="/company/events/">Events</a></li>
+<li class="list-item"><a href="/jobs/">Careers</a></li>
+<li class="list-item"><a href="/company/contact-info/">Legal</a></li>
+</ul>
+</li>
+</ul>
+<a class="secondary-menu-item" href="/support/contact/">Contact Us</a>
+<ul class="list list-vert SL_swap secondary-menu-item masthead-top-item masthead-top-i18n" id="smartling-lang-dropdown">
+<li class="first"><a href="#">English<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="https://www.zendesk.co.uk">English (UK)</a></li>
+<li class="list-item"><a href="https://www.zendesk.es">Español</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.mx">Español (LATAM)</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.br">Português</a></li>
+<li class="list-item"><a href="https://www.zendesk.fr">Français</a></li>
+<li class="list-item"><a href="https://www.zendesk.de">Deutsch</a></li>
+<li class="list-item"><a href="https://www.zendesk.it">Italiano</a></li>
+<li class="list-item"><a href="https://www.zendesk.nl">Nederlands</a></li>
+<li class="list-item"><a href="https://www.zendesk.co.jp">日本語</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.ru">Pусский</a></li>
+<li class="list-item"><a href="https://www.zendesk.kr">한국어</a></li>
+</ul>
+</ul>
+</div>
+<div class="masthead-stuck-target">
+<div class="js-stuck-inner">
+<header class="site-title">
+<a href="/" class="zendesk-logo" rel="home"></a>
+</header>
+<div class="primary-menu menu">
+<div class="primary-menu-anchor"></div>
+<nav class="primary-menu-list-wrap">
+<ul id="menu-header-navigation-mini" class="primary-menu-list">
+<li id="smartling-nvg-product" class="SL_swap menu-item list-parent ">
+<a href="/product/tour/" class="menu-heading link-tier-1">Products</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>The Zendesk Family</h2>
+<p>The Zendesk family of products work together to help you improve customer relationships</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/support/">
+<li class="support-product">
+<span class='product-logo'></span>
+<h4>support</h4>
+<p class="product-subheader">Multi-channel customer service</p>
+</li>
+</a>
+<a href="/help-center/">
+<li class="help-product">
+<span class='product-logo'></span>
+<h4>help&nbsp;center</h4>
+<p class="product-subheader">Knowledge base and self-service</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/chat/">
+<li class="chat-product">
+<span class='product-logo'></span>
+<h4>chat</h4>
+<p class="product-subheader">Live chat software</p>
+</li>
+</a>
+<a href="/talk/">
+<li class="talk-product">
+<span class='product-logo'></span>
+<h4>talk</h4>
+<p class="product-subheader">Integrated call center software</p>
+</li>
+</a>
+<a href="/message/">
+<li class="message-product">
+<span class='product-logo'></span>
+<h4>message</h4><span class="new-button">new</span>
+<p class="product-subheader">Social messaging apps</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/explore/">
+<li class="explore-product">
+<span class='product-logo'></span>
+<h4>explore</h4><span class="new-button">new</span>
+<p class="product-subheader">Analytics and reporting</p>
+</li>
+</a>
+<a href="/connect/">
+<li class="connect-product">
+<span class='product-logo'></span>
+<h4>connect</h4><span class="new-button">new</span>
+<p class="product-subheader">Segmentation and targeting</p>
+</li>
+</a>
+<a href="/inbox/">
+<li class="inbox-product">
+<span class='product-logo'></span>
+<h4>inbox</h4>
+<p class="product-subheader">Shared team inbox</p>
+</li>
+</a>
+</ul>
+</div>
+<ul class="bottom-options">
+<li class="title">
+<h3>The flexibility to go even further:</h3>
+</li>
+<li>
+<a href="/apps/"><h3>Zendesk Apps Marketplace</h3></a>
+</li>
+<li>
+<a href="/embeddables/"><h3>Embeddables</h3></a>
+</li>
+</ul>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-pricing" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/product/pricing/">Pricing</a></li>
+<li id="smartling-nvg-demo" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/demo/">Demo</a></li>
+<li id="smartling-nvg-solutions" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/enterprise/">Solutions</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Solutions</h2>
+<p class="solution-subheader">The Zendesk family of products helps improve relationships with customers and employees, for companies big and small</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/enterprise/">
+<li>
+<h5>Customer support for enterprise<h5>
+<p class="solution-subheader">Innovation, security, and integration—at scale</p>
+</li>
+</a>
+<a href="/smb/">
+<li>
+<h5>Support for growing businesses<h5>
+<p class="solution-subheader">Flexibility to start small and grow</p>
+</li></a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/internal-help-desk/">
+<li>
+<h5>Internal service desk for employees<h5>
+<p class="solution-subheader">Service desks for HR, IT, and more </p>
+</li>
+</a>
+<a href="/mobile-solutions/">
+<li>
+<h5>Customer support for mobile<h5>
+<p class="solution-subheader">Engage with customers everywhere</p>
+</li></a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-customers" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/customer-experience/">Services</a></li>
+<li id="smartling-nvg-resources" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/resources/">Resources</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Resources</h2>
+<p>Learn more about Zendesk and how to create a better customer experience</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/resources/">
+<li>
+<h5>Library<h5>
+<p>Guides, research, videos, and resources</p>
+</li>
+</a>
+<a href="/blog/">
+<li>
+<h5>Blog<h5>
+<p>News, tips, and best practices</p>
+</li>
+</a>
+<a href="/why-zendesk/customers/">
+<li>
+<h5>Customer Stories<h5>
+<p>See what success with Zendesk looks like</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/company/events/">
+<li>
+<h5>Events<h5>
+<p>Come meet us in person</p>
+</li>
+</a>
+<a href="/support/webinars/">
+<li>
+<h5>Live Webinars<h5>
+<p>Online events</p>
+</li>
+</a>
+<a href="//relate.zendesk.com/">
+<li>
+<h5>Relate by Zendesk<h5>
+<p>Customers. Colleagues. Community. It&apos;s complicated.</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/partner/">
+<li>
+<h5>Partners<h5>
+<p>How to locate or become a Zendesk partner</p>
+</li>
+</a>
+<a href="//developer.zendesk.com/">
+<li>
+<h5>API &#038; Developers<h5>
+<p>Info for building things with Zendesk</p>
+</li>
+</a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li class="list-parent register-desktop"><a href="/register/" id="nav-get-started"><span class="register">Get started</span></a></li>
+<li class="register-mobile">
+<a id="nav-get-started-mobile" href="/register/">Get started</a>
+</li>
+</ul>
+</nav>
+</div>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</header>
+<article class="home-tour home-golion">
+<span style="position: absolute; z-index: -999;">
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/on-combined-2X.png" alt="" width="0" height="0"/>
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/hover-combined-2X.png" alt="" width="0" height="0"/>
+</span>
+<article class="mod-block hero-background">
+<div class="video-outer-wrapper">
+<div class="video-inner-wrap">
+<video id="hero-video" class="hero-video">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.webm" type="video/webm; codecs=vp8,vorbis">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.mp4" type="video/mp4">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.ogv" type="video/ogg; codecs=theora,vorbis">
+</video>
+</div>
+<div class="video-cta-wrapper SL_swap" id="video_id_reintroducing_zendesk">
+<a href="//fast.wistia.com/embed/iframe/sxpw0wdxff?autoPlay=true&popover=true" class="wistia-popover[height=568,playerColor=7b796a,width=960] video-play-cta">Watch the video</a>
+</div>
+</div>
+<section class="mod-section">
+<div class="content">
+<div class="row the-hero">
+<div class="inner">
+<div class="video-container">
+</div>
+<div class="center">
+<h1>Let&apos;s make things better</h1>
+<div class="sub">Zendesk builds software for better customer relationships</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</article>
+<article class="mod-block zendesk-family">
+<div class="content">
+<section class="mod-section">
+<div class="inner">
+<div class="center relationship-text">
+<p>
+Good relationships take work. They require knowledge and the tools to get the <br class="hide-mobile"> job done right. That&apos;s what Zendesk is for.
+</p>
+<p>
+<span>Our products allow businesses to be more reliable, flexible, and scalable.</span>
+<br>
+<span>They help improve communication and make sense of massive amounts of data.</span>
+<br>
+<span>Above all, they help you turn interactions into lasting relationships.</span>
+</p>
+</div>
+<div class="center zendesk-family-products">
+<ol>
+<li>Redacts a regular credit card 411111▇▇▇▇▇▇1111 in text</li>
+<li>Redacts a credit card with spaces 4111 11▇▇ ▇▇▇▇ 1111 in a line</li>
+<li>Redacts a credit card with dashes 4111-11▇▇-▇▇▇▇-1111 next to words</li>
+<li class="4111111111111111"> does not redact when 4111 11▇▇ ▇▇▇▇ 1111 card is a class</li>
+<li>41111111111 bottles of beer on the wall is not a credit card number</li>
+<li>VISA example 4111 11▇▇ ▇▇▇▇ 1111 mastercard 5500 00▇▇ ▇▇▇▇ 0004</li>
+<li>this is an 3400 00▇▇ ▇▇▇0 009 american express example</li>
+<li>Does not redact if  & inside 4111&111111111111</li>
+<li>你好 4111 11▇▇ ▇▇▇▇ 1111 there invalid characters</li>
+<li>4111.1111.1111.1111</li>
+<li>(411)1-111-11111-1111</li>
+<li>4111/1111/1111/1111</li>
+<li>4111:1111 1111 1111</li>
+<li>click this link http://support.zendesk.com/tickets/4111111111111111 </li>
+<li>credit card number followed by numbers 612999921404471347800000</li>
+<li>credit card number 612999▇▇▇▇▇▇▇▇▇3478</li>
+<li>card number followed by expiration date 4111 11▇▇ ▇▇▇▇ 1111 03/17</li>
+</ol>
+<p>
+test 4111 11▇▇ ▇▇▇▇ 1111 with a new line \n 4111 11▇▇ ▇▇▇▇ 1111 \n 4111 \n 1111\n 1111\n 1111
+</p>
+http://support.zendesk.com/tickets/4111111111111111
+<a class="4111111111111111" href="http://support.zendesk.com/tickets/4111111111111111">click here</a>
+<a class="product-link" href="/support/">
+<span class="feature-icon-common icon-support"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-support.png" alt="Zendesk Support logo" width="72" height="25"/>
+</a>
+<a href="/help-center/" class="product-link">
+<span class="feature-icon-common icon-help-center"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-help-center.png" alt="Zendesk Help Center logo" width="72" height="25"/>
+</a>
+<a href="/chat/" class="product-link">
+<span class="feature-icon-common icon-chat"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-chat.png" alt="Zendesk Chat logo" width="72" height="25"/>
+</a>
+<a href="/talk/" class="product-link">
+<span class="feature-icon-common icon-talk"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-talk.png" alt="Zendesk Talk logo" width="72" height="25"/>
+</a>
+<a href="/message/" class="product-link">
+<span class="feature-icon-common icon-message"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-message.png" alt="Zendesk Message logo" width="72" height="25"/>
+</a>
+<a href="/connect/" class="product-link">
+<span class="feature-icon-common icon-connect"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-connect.png" alt="Zendesk Connect logo" width="72" height="25"/>
+</a>
+<a href="/explore/" class="product-link">
+<span class="feature-icon-common icon-explore"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-explore.png" alt="Zendesk Explore logo" width="72" height="25"/>
+</a>
+</div>
+<div class="center cta-section">
+<a class="btn btn-content-cta" id="home-whats-new" href="/whats-new/">See what&apos;s new</a>
+<a class="btn btn-conversion-cta" id="home-demo-request" href="/demo/">Request a demo</a>
+</div>
+</div>
+</section>
+</div>
+</article>
+</article>
+<script charset="ISO-8859-1" src="//fast.wistia.net/static/popover-v1.js"></script>
+</div>
+<div class="clearfix"></div>
+<footer class="clear">
+<div class="sitemap mega-footer">
+<div class="col-960">
+<nav class="primary-menu-list-wrap">
+<ul id="menu-footer-navigation" class="primary-menu-list">
+<li id="smartling-nav-footer-product" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/support/">Our Products</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/">Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/">Help Center</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/chat/">Chat</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/talk/">Talk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/message/">Message</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/inbox/">Inbox Team Email</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/explore/">Explore</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/connect/">Connect</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/apps/">Integrations &#038; Apps</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/embeddables/">Embeddables</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/zendesk-insights/">Insights &amp; Analytics</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/whats-new/">Product Updates</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-features" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Top Features</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/features/ticketing-system/">Ticketing System</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/knowledge-base-software/">Knowledge Base</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/community-software/">Community Forums</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/">Help Desk Software</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/internal-help-desk/it-help-desk-software/">IT Help Desk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/zendesk-security/">Security</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/tech-specs/">Tech Specs</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-resources" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/resources/">Resources</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="//support.zendesk.com/hc/en-us/">Product Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/demo/">Request a demo</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/">Library</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_norewrite"><a href="/blog/">Zendesk Blog</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/webinars/">Live webinars</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/training/#training">Training</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://developers.zendesk.com">API &#038; Developers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/partners/">Services &#038; Partners</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/lp/retail/">For Retailers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/">Relate by Zendesk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/why-zendesk/customers/">Customer Stories</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/">Services</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-company" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/about/">Company</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/about/">About us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/company/press/">Press</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://investor.zendesk.com">Investors</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/jobs/">Careers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://www.neighborfoundation.org/">Neighbor Foundation</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/contact/">Contact Us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/sitemap/">Sitemap</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://status.zendesk.com">System Status</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://help.zendesk.com/hc/en-us">Product Help</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-favorites" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Favorite Things</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/startups/">Zendesk for Startups</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://relate.zendesk.com/articles/shit-support-agents-say/">Sh*t Agents Say</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="https://www.youtube.com/watch?v=wPtnoRqQa5U">Zoe Calls Home</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/benchmark-your-support/">Zendesk Benchmark</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/small-business/">Zendesk for Small Business</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/gartner-magic-quadrant-crm/">Gartner CRM Magic Quadrant</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/education/interview-questions-hiring-great-customer-service-reps/">Hiring Great Support Teams</a></li>
+</ul>
+</div>
+</li>
+</ul>
+<div style="clear: both;"></div>
+</nav>
+<div id="newsletter-form" class="newsletter-sub">
+<h3>Enter the Fold</h3>
+<p>Join the elite group of other people who have also signed up for our mailing list.</p>
+<form id="newsletter" class="form-gray" method="post" name="eloquaform">
+<label class="success"><span></span>Welcome to the club!</label>
+<ul>
+<li class="error">
+<div class="depth-wrap">
+<input name="owner[email]" id="owner[email]" type="text" placeholder="What&apos;s your email?" class="email">
+<a class="register"></a>
+</div>
+<label style="display: block; opacity: 1;"><span></span>Please use a valid email</label>
+</li>
+<li style="display:none">
+<input type="hidden" name="elqFormName" id="elqFormName" value="WebsiteNewsletterSignup_new">
+</li>
+</ul>
+</form>
+<div class="l-island l-island-right social clear">
+<span itemscope itemtype="https://schema.org/Organization">
+<link itemprop="url" href="https://www.zendesk.com">
+<a itemprop="sameAs" href="//plus.google.com/+zendesk" class="ent-text ico-gplus" rel="publisher">&#59639;</a>
+<a itemprop="sameAs" href="//www.facebook.com/zendesk" class="ent-text ico-facebook">&#59636;</a>
+<a itemprop="sameAs" href="//www.twitter.com/zendesk" class="ent-text ico-twitter">&#59634;</a>
+<a itemprop="sameAs" href="//www.linkedin.com/company/zendesk" class="ent-text ico-linkedin">&#59645;</a>
+<a itemprop="sameAs" href="http://www.slideshare.net/zendesk" class="ent-text ico-slideshare"></a>
+<a itemprop="sameAs" href="//instagram.com/zendesk/" class="ent-text ico-instagram">&#59657;</a>
+</span>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</div>
+<div class="legal clear">
+<div class="col-960">
+<a href="//www.zendesk.com/company/customers-partners/#terms-of-use">Terms of Use</a>
+<a href="//www.zendesk.com/company/customers-partners/#privacy-policy">Privacy Policy</a>
+<a href="//www.zendesk.com/company/customers-partners/#cookie-policy">Cookie Policy</a>
+<a href="https://www.zendesk.com/legal/">&copy;Zendesk 2017</a>
+</div>
+</div>
+<div class="universe-search">
+<div class="universe-search-close ent-text"></div>
+<div class="col-960">
+<div class="universe-search-help"><span class="universe-search-help-count">0</span> results. <br/>How about another try?</div>
+<div class="universe-search-form">
+<span class="universe-search-icon ent-text"></span>
+<input type="text" name="search" class="universe-search-input" placeholder="Start typing to get your search on..." value=""/>
+</div>
+<div class="universe-search-results"></div>
+<div class="universe-search-pagination" style="display:none">
+<ol class="universe-search-pagination-list"> </ol>
+</div>
+</div>
+</div>
+<div class="search">
+<div class="col-960">
+<a href="javascript:;" class="search-launcher"><span class="ent-text icon"></span>Search Zendesk <span class="cursor"></span></a>
+</div>
+</div>
+<div class="clearfix"></div>
+</footer>
+
+<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" data-apikey="14b4da2b1698aa9ce8da80a183366f26"></script>
+<script type="text/javascript" src="//api.demandbase.com/api/v2/ip.js?key=cb334198e711721abab9b3d4c785e482544ca07f&var=dbase"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/plugins.min.b8103b49.js"></script><script src="https://d1eipm3vz40hy0.cloudfront.net/js/webutils.min.d107191a.js"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/global.min.04c36daa.js"></script>
+
+<script type="text/javascript">
+  webutils.styleHeader();
+  webutils.gauge();
+
+  var emeaCountryCodes = new Array('UK', 'GB', 'IM', 'GI', 'JE', 'GG', 'AT', 'BE', 'CY', 'EE', 'FI', 'FR', 'DE', 'EL', 'IE', 'IT', 'LV', 'LU', 'MT', 'NL', 'PT', 'SK', 'SI', 'ES', 'MC', 'VA', 'SM', 'ME', 'MC', 'LU', 'XK', 'KV', 'GR', 'AD')
+    , emeaDomainNames  = new Array('www.zendesk.de', 'www.zendesk.es', 'www.zendesk.fr', 'www.zendesk.it', 'www.zendesk.nl');
+
+  if((typeof dbase !== 'undefined' && $.inArray(dbase.registry_country_code, emeaCountryCodes) > -1) || $.inArray(window.location.hostname, emeaDomainNames) > -1) {
+    webutils.cookieNotice();
+  }
+
+  webutils.loadEloqua();
+</script>
+<script type="text/javascript">
+  dataLayer = [];
+</script>
+
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-Z4DV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+<script>
+  if (!window.potentialBot) {
+    webutils.loadGTM();
+    webutils.processGA();
+    webutils.saveEloquaGuid();
+  }
+</script>
+<script type="text/javascript">
+  $(document).ready(function(){
+    webutils.lockTopNavigation(); // make top navigation sticky
+
+    var animationHelpers = {
+      appearDone: function(e) {
+        $(e.currentTarget)
+          .addClass("entrance-done")
+          .off("animationend", animationHelpers.appearDone)
+          .on("animationend", animationHelpers.hoverState);
+        $(e.currentTarget).parent()
+          .on("mouseover", animationHelpers.mouseOver);
+      },
+      hoverState: function(e) {
+        $(e.currentTarget).removeClass("hover");
+      },
+      mouseOver: function(e){
+        $(e.currentTarget).children(".feature-icon-common").addClass("hover");
+      },
+      curtainUp: function(e) {
+        var curtainCall = animationHelpers.$family.offset().top;
+        var windowOffset   = window.pageYOffset + window.innerHeight;
+
+        if (curtainCall < windowOffset) {
+          animationHelpers.$family.addClass("curtain-up");
+          $(window).off("scroll", animationHelpers.curtainUp);
+        }
+      },
+      $family: $(".zendesk-family-products")
+    }
+
+    $(".product-link").children(".feature-icon-common").on("animationend", animationHelpers.appearDone);
+
+    if (!_isMobile) {
+      document.getElementById("hero-video").play();
+    }
+    $(window).scroll(animationHelpers.curtainUp);
+    animationHelpers.curtainUp();
+
+  });
+
+</script>
+</body>
+</html>

--- a/test/samples/html_example_with_line.html
+++ b/test/samples/html_example_with_line.html
@@ -1,0 +1,672 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js no-pass-type ie6 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js no-pass-type ie7 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js no-pass-type ie8 oldie" id="unsupported" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if IE 9]>    <html class="no-js no-pass-type ie9" lang="en" prefix="og: http://ogp.me/ns#"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" prefix="og: http://ogp.me/ns#"> <!--<![endif]-->
+<head>
+<title>Zendesk | Customer Service Software &amp; Support Ticket System</title>
+<script>
+    // Create ga object before optimizely loads, since the snippet for
+    // analytics.js is being loaded async through GTM
+    window.ga = window.ga || function() {
+      (window.ga.q = window.ga.q || []).push(arguments)
+    };
+  </script>
+<script src="//cdn.optimizely.com/js/112699136.js"></script>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta charset="UTF-8"/>
+<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<meta name="google-site-verification" content="2q8u-0_6HxJZdS7l7LYlf-WDEYwIPvdJ_XVujkTFNCY"/>
+<meta name="viewport" content="width=device-width">
+<!--[if lt IE 9]>
+      <script src="//d26a57ydsghvgx.cloudfront.net/www/public/assets/js/css3-mediaqueries.js"></script>
+    <![endif]-->
+<link rel="profile" href="https://gmpg.org/xfn/11"/>
+<link rel="dns-prefetch" href="//d16cvnquvjw7pr.cloudfront.net">
+<link rel="dns-prefetch" href="//ajax.googleapis.com">
+<link rel="shortcut icon" href="//d1eipm3vz40hy0.cloudfront.net/images/logos/zendesk-favicon.ico"/>
+
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk144.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk114.png">
+
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk72.png">
+
+<link rel="apple-touch-icon-precomposed" href="//d26a57ydsghvgx.cloudfront.net/www/public/assets/images/logos/zendesk57.png">
+<meta property="og:image" content="https://d16cvnquvjw7pr.cloudfront.net/images/blog/zendesk-default-placeholder.jpg"/>
+<meta category="og:category" content=""/>
+<meta name="description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<link rel="canonical" href="https://www.zendesk.com"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="article"/>
+<meta property="og:title" content="Zendesk | Customer Service Software &amp; Support Ticket System"/>
+<meta property="og:description" content="Customer service software and support ticket system by Zendesk®. Web-based help desk software used by 200,000+ organizations worldwide. Free 30 day trial."/>
+<meta property="og:url" content="https://www.zendesk.com"/>
+<meta property="og:site_name" content="Zendesk"/>
+<link href="https://d1eipm3vz40hy0.cloudfront.net/css/screen.min.e20e646a.css" media="all" rel="stylesheet" type="text/css"/></head>
+<body data-useragent class="lang-en responsive " lang="en-US">
+<script type="text/javascript">
+  window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+  heap.load("1646711747");
+</script>
+<script type="text/javascript">
+  (function() {
+    var loadConvertro = function() {
+      (function(c){var e=document.createElement("script");
+      e.type='text/javascript';e.async=true;
+      e.src='//d1ivexoxmp59q7.cloudfront.net/'+c+'/live.js';
+      var n=document.getElementsByTagName('script')[0];
+      n.parentNode.insertBefore(e,n);})('zendesk');
+    };
+
+    if (!window.potentialBot) {
+      loadConvertro();
+    }
+  }());
+</script>
+<header class="masthead-refresh  " role="banner">
+<div class="masthead-top">
+<div class="secondary-menu menu">
+<a class="secondary-menu-item" href="/login/">Log In</a>
+<a class="secondary-menu-item" href="//help.zendesk.com/">Product Support</a>
+<ul class="secondary-menu-item company">
+<li class="first">
+<a href="#">Company<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="/about/">About us</a></li>
+<li class="list-item"><a href="/company/press/">Press</a></li>
+<li class="list-item SL_norewrite"><a href="//investor.zendesk.com/">Investors</a></li>
+<li class="list-item SL_norewrite"><a href="/company/events/">Events</a></li>
+<li class="list-item"><a href="/jobs/">Careers</a></li>
+<li class="list-item"><a href="/company/contact-info/">Legal</a></li>
+</ul>
+</li>
+</ul>
+<a class="secondary-menu-item" href="/support/contact/">Contact Us</a>
+<ul class="list list-vert SL_swap secondary-menu-item masthead-top-item masthead-top-i18n" id="smartling-lang-dropdown">
+<li class="first"><a href="#">English<span class="ent-text"></span></a>
+<ul class="list-sub">
+<span class="pin"></span>
+<li class="list-item"><a href="https://www.zendesk.co.uk">English (UK)</a></li>
+<li class="list-item"><a href="https://www.zendesk.es">Español</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.mx">Español (LATAM)</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.br">Português</a></li>
+<li class="list-item"><a href="https://www.zendesk.fr">Français</a></li>
+<li class="list-item"><a href="https://www.zendesk.de">Deutsch</a></li>
+<li class="list-item"><a href="https://www.zendesk.it">Italiano</a></li>
+<li class="list-item"><a href="https://www.zendesk.nl">Nederlands</a></li>
+<li class="list-item"><a href="https://www.zendesk.co.jp">日本語</a></li>
+<li class="list-item"><a href="https://www.zendesk.com.ru">Pусский</a></li>
+<li class="list-item"><a href="https://www.zendesk.kr">한국어</a></li>
+</ul>
+</ul>
+</div>
+<div class="masthead-stuck-target">
+<div class="js-stuck-inner">
+<header class="site-title">
+<a href="/" class="zendesk-logo" rel="home"></a>
+</header>
+<div class="primary-menu menu">
+<div class="primary-menu-anchor"></div>
+<nav class="primary-menu-list-wrap">
+<ul id="menu-header-navigation-mini" class="primary-menu-list">
+<li id="smartling-nvg-product" class="SL_swap menu-item list-parent ">
+<a href="/product/tour/" class="menu-heading link-tier-1">Products</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>The Zendesk Family</h2>
+<p>The Zendesk family of products work together to help you improve customer relationships</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/support/">
+<li class="support-product">
+<span class='product-logo'></span>
+<h4>support</h4>
+<p class="product-subheader">Multi-channel customer service</p>
+</li>
+</a>
+<a href="/help-center/">
+<li class="help-product">
+<span class='product-logo'></span>
+<h4>help&nbsp;center</h4>
+<p class="product-subheader">Knowledge base and self-service</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/chat/">
+<li class="chat-product">
+<span class='product-logo'></span>
+<h4>chat</h4>
+<p class="product-subheader">Live chat software</p>
+</li>
+</a>
+<a href="/talk/">
+<li class="talk-product">
+<span class='product-logo'></span>
+<h4>talk</h4>
+<p class="product-subheader">Integrated call center software</p>
+</li>
+</a>
+<a href="/message/">
+<li class="message-product">
+<span class='product-logo'></span>
+<h4>message</h4><span class="new-button">new</span>
+<p class="product-subheader">Social messaging apps</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/explore/">
+<li class="explore-product">
+<span class='product-logo'></span>
+<h4>explore</h4><span class="new-button">new</span>
+<p class="product-subheader">Analytics and reporting</p>
+</li>
+</a>
+<a href="/connect/">
+<li class="connect-product">
+<span class='product-logo'></span>
+<h4>connect</h4><span class="new-button">new</span>
+<p class="product-subheader">Segmentation and targeting</p>
+</li>
+</a>
+<a href="/inbox/">
+<li class="inbox-product">
+<span class='product-logo'></span>
+<h4>inbox</h4>
+<p class="product-subheader">Shared team inbox</p>
+</li>
+</a>
+</ul>
+</div>
+<ul class="bottom-options">
+<li class="title">
+<h3>The flexibility to go even further:</h3>
+</li>
+<li>
+<a href="/apps/"><h3>Zendesk Apps Marketplace</h3></a>
+</li>
+<li>
+<a href="/embeddables/"><h3>Embeddables</h3></a>
+</li>
+</ul>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-pricing" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/product/pricing/">Pricing</a></li>
+<li id="smartling-nvg-demo" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/demo/">Demo</a></li>
+<li id="smartling-nvg-solutions" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/enterprise/">Solutions</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Solutions</h2>
+<p class="solution-subheader">The Zendesk family of products helps improve relationships with customers and employees, for companies big and small</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/enterprise/">
+<li>
+<h5>Customer support for enterprise<h5>
+<p class="solution-subheader">Innovation, security, and integration—at scale</p>
+</li>
+</a>
+<a href="/smb/">
+<li>
+<h5>Support for growing businesses<h5>
+<p class="solution-subheader">Flexibility to start small and grow</p>
+</li></a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/internal-help-desk/">
+<li>
+<h5>Internal service desk for employees<h5>
+<p class="solution-subheader">Service desks for HR, IT, and more </p>
+</li>
+</a>
+<a href="/mobile-solutions/">
+<li>
+<h5>Customer support for mobile<h5>
+<p class="solution-subheader">Engage with customers everywhere</p>
+</li></a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li id="smartling-nvg-customers" class="SL_swap menu-item list-parent "><a class="menu-heading link-tier-1" href="/customer-experience/">Services</a></li>
+<li id="smartling-nvg-resources" class="SL_swap menu-item list-parent ">
+<a class="menu-heading link-tier-1" href="/resources/">Resources</a>
+<div class="pin-container"><span class="pin"></span></div>
+<div class="primary-menu-list-dropdown">
+<section>
+<div class="col-5">
+<h2>Resources</h2>
+<p>Learn more about Zendesk and how to create a better customer experience</p>
+</div>
+<div class="col-5">
+<ul>
+<a href="/resources/">
+<li>
+<h5>Library<h5>
+<p>Guides, research, videos, and resources</p>
+</li>
+</a>
+<a href="/blog/">
+<li>
+<h5>Blog<h5>
+<p>News, tips, and best practices</p>
+</li>
+</a>
+<a href="/why-zendesk/customers/">
+<li>
+<h5>Customer Stories<h5>
+<p>See what success with Zendesk looks like</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/company/events/">
+<li>
+<h5>Events<h5>
+<p>Come meet us in person</p>
+</li>
+</a>
+<a href="/support/webinars/">
+<li>
+<h5>Live Webinars<h5>
+<p>Online events</p>
+</li>
+</a>
+<a href="//relate.zendesk.com/">
+<li>
+<h5>Relate by Zendesk<h5>
+<p>Customers. Colleagues. Community. It&apos;s complicated.</p>
+</li>
+</a>
+</ul>
+</div>
+<div class="col-5">
+<ul>
+<a href="/partner/">
+<li>
+<h5>Partners<h5>
+<p>How to locate or become a Zendesk partner</p>
+</li>
+</a>
+<a href="//developer.zendesk.com/">
+<li>
+<h5>API &#038; Developers<h5>
+<p>Info for building things with Zendesk</p>
+</li>
+</a>
+</ul>
+</div>
+</section>
+</div>
+</li>
+<li class="list-parent register-desktop"><a href="/register/" id="nav-get-started"><span class="register">Get started</span></a></li>
+<li class="register-mobile">
+<a id="nav-get-started-mobile" href="/register/">Get started</a>
+</li>
+</ul>
+</nav>
+</div>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</header>
+<article class="home-tour home-golion">
+<span style="position: absolute; z-index: -999;">
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/on-combined-2X.png" alt="" width="0" height="0"/>
+<img src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/hover-combined-2X.png" alt="" width="0" height="0"/>
+</span>
+<article class="mod-block hero-background">
+<div class="video-outer-wrapper">
+<div class="video-inner-wrap">
+<video id="hero-video" class="hero-video">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.webm" type="video/webm; codecs=vp8,vorbis">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.mp4" type="video/mp4">
+<source src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/HomepageHero_1x.ogv" type="video/ogg; codecs=theora,vorbis">
+</video>
+</div>
+<div class="video-cta-wrapper SL_swap" id="video_id_reintroducing_zendesk">
+<a href="//fast.wistia.com/embed/iframe/sxpw0wdxff?autoPlay=true&popover=true" class="wistia-popover[height=568,playerColor=7b796a,width=960] video-play-cta">Watch the video</a>
+</div>
+</div>
+<section class="mod-section">
+<div class="content">
+<div class="row the-hero">
+<div class="inner">
+<div class="video-container">
+</div>
+<div class="center">
+<h1>Let&apos;s make things better</h1>
+<div class="sub">Zendesk builds software for better customer relationships</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</article>
+<article class="mod-block zendesk-family">
+<div class="content">
+<section class="mod-section">
+<div class="inner">
+<div class="center relationship-text">
+<p>
+Good relationships take work. They require knowledge and the tools to get the <br class="hide-mobile"> job done right. That&apos;s what Zendesk is for.
+</p>
+<p>
+<span>Our products allow businesses to be more reliable, flexible, and scalable.</span>
+<br>
+<span>They help improve communication and make sense of massive amounts of data.</span>
+<br>
+<span>Above all, they help you turn interactions into lasting relationships.</span>
+</p>
+</div>
+<div class="center zendesk-family-products">
+<ol>
+<li>Redacts a regular credit card 411111▇▇▇▇▇▇1111 in text</li>
+<li>Redacts a credit card with spaces 4111 11▇▇ ▇▇▇▇ 1111 in a line</li>
+<li>Redacts a credit card with dashes 4111-11▇▇-▇▇▇▇-1111 next to words</li>
+<li class="411111▇▇▇▇▇▇1111"> does not redact when 4111 11▇▇ ▇▇▇▇ 1111 card is a class</li>
+<li>41111111111 bottles of beer on the wall is not a credit card number</li>
+<li>VISA example 4111 11▇▇ ▇▇▇▇ 1111 mastercard 5500 00▇▇ ▇▇▇▇ 0004</li>
+<li>this is an 3400 00▇▇ ▇▇▇0 009 american express example</li>
+<li>Does not redact if  & inside 4111&111111111111</li>
+<li>你好 4111 11▇▇ ▇▇▇▇ 1111 there invalid characters</li>
+<li>4111.1111.1111.1111</li>
+<li>(411)1-111-11111-1111</li>
+<li>4111/1111/1111/1111</li>
+<li>4111:1111 1111 1111</li>
+<li>click this link http://support.zendesk.com/tickets/4111111111111111 </li>
+<li>credit card number followed by numbers 612999921404471347800000</li>
+<li>credit card number 612999▇▇▇▇▇▇▇▇▇3478</li>
+<li>card number followed by expiration date 4111 11▇▇ ▇▇▇▇ 1111 03/17</li>
+</ol>
+<p>
+test 4111 11▇▇ ▇▇▇▇ 1111 with a new line \n 4111 11▇▇ ▇▇▇▇ 1111 \n 4111 \n 1111\n 1111\n 1111
+</p>
+http://support.zendesk.com/tickets/4111111111111111
+<a class="411111▇▇▇▇▇▇1111" href="http://support.zendesk.com/tickets/4111111111111111">click here</a>
+<a class="product-link" href="/support/">
+<span class="feature-icon-common icon-support"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-support.png" alt="Zendesk Support logo" width="72" height="25"/>
+</a>
+<a href="/help-center/" class="product-link">
+<span class="feature-icon-common icon-help-center"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-help-center.png" alt="Zendesk Help Center logo" width="72" height="25"/>
+</a>
+<a href="/chat/" class="product-link">
+<span class="feature-icon-common icon-chat"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-chat.png" alt="Zendesk Chat logo" width="72" height="25"/>
+</a>
+<a href="/talk/" class="product-link">
+<span class="feature-icon-common icon-talk"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-talk.png" alt="Zendesk Talk logo" width="72" height="25"/>
+</a>
+<a href="/message/" class="product-link">
+<span class="feature-icon-common icon-message"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-message.png" alt="Zendesk Message logo" width="72" height="25"/>
+</a>
+<a href="/connect/" class="product-link">
+<span class="feature-icon-common icon-connect"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-connect.png" alt="Zendesk Connect logo" width="72" height="25"/>
+</a>
+<a href="/explore/" class="product-link">
+<span class="feature-icon-common icon-explore"></span>
+<img class="product-logo" src="//d1eipm3vz40hy0.cloudfront.net/images/p-home/relation-shapes-logo-explore.png" alt="Zendesk Explore logo" width="72" height="25"/>
+</a>
+</div>
+<div class="center cta-section">
+<a class="btn btn-content-cta" id="home-whats-new" href="/whats-new/">See what&apos;s new</a>
+<a class="btn btn-conversion-cta" id="home-demo-request" href="/demo/">Request a demo</a>
+</div>
+</div>
+</section>
+</div>
+</article>
+</article>
+<script charset="ISO-8859-1" src="//fast.wistia.net/static/popover-v1.js"></script>
+</div>
+<div class="clearfix"></div>
+<footer class="clear">
+<div class="sitemap mega-footer">
+<div class="col-960">
+<nav class="primary-menu-list-wrap">
+<ul id="menu-footer-navigation" class="primary-menu-list">
+<li id="smartling-nav-footer-product" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/support/">Our Products</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/">Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/">Help Center</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/chat/">Chat</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/talk/">Talk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/message/">Message</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/inbox/">Inbox Team Email</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/explore/">Explore</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/connect/">Connect</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/apps/">Integrations &#038; Apps</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/embeddables/">Embeddables</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/zendesk-insights/">Insights &amp; Analytics</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/whats-new/">Product Updates</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-features" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Top Features</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/features/ticketing-system/">Ticketing System</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/knowledge-base-software/">Knowledge Base</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-center/community-software/">Community Forums</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/help-desk-software/">Help Desk Software</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/internal-help-desk/it-help-desk-software/">IT Help Desk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/zendesk-security/">Security</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/product/tech-specs/">Tech Specs</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-resources" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/resources/">Resources</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="//support.zendesk.com/hc/en-us/">Product Support</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/demo/">Request a demo</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/">Library</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_norewrite"><a href="/blog/">Zendesk Blog</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/webinars/">Live webinars</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/training/#training">Training</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://developers.zendesk.com">API &#038; Developers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/partners/">Services &#038; Partners</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="/lp/retail/">For Retailers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/">Relate by Zendesk</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/why-zendesk/customers/">Customer Stories</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/customer-experience/">Services</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-company" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/about/">Company</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/about/">About us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/company/press/">Press</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://investor.zendesk.com">Investors</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/jobs/">Careers</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="http://www.neighborfoundation.org/">Neighbor Foundation</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/support/contact/">Contact Us</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/sitemap/">Sitemap</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://status.zendesk.com">System Status</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://help.zendesk.com/hc/en-us">Product Help</a></li>
+</ul>
+</div>
+</li>
+<li id="smartling-nav-footer-favorites" class="SL_swap menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children list-parent "><a href="/">Favorite Things</a>
+<div class="primary-menu-list-dropdown"><span class="pin"></span>
+<ul>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/startups/">Zendesk for Startups</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="http://relate.zendesk.com/articles/shit-support-agents-say/">Sh*t Agents Say</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children SL_hide"><a href="https://www.youtube.com/watch?v=wPtnoRqQa5U">Zoe Calls Home</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/benchmark-your-support/">Zendesk Benchmark</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/small-business/">Zendesk for Small Business</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="/resources/gartner-magic-quadrant-crm/">Gartner CRM Magic Quadrant</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom no_children "><a href="https://relate.zendesk.com/education/interview-questions-hiring-great-customer-service-reps/">Hiring Great Support Teams</a></li>
+</ul>
+</div>
+</li>
+</ul>
+<div style="clear: both;"></div>
+</nav>
+<div id="newsletter-form" class="newsletter-sub">
+<h3>Enter the Fold</h3>
+<p>Join the elite group of other people who have also signed up for our mailing list.</p>
+<form id="newsletter" class="form-gray" method="post" name="eloquaform">
+<label class="success"><span></span>Welcome to the club!</label>
+<ul>
+<li class="error">
+<div class="depth-wrap">
+<input name="owner[email]" id="owner[email]" type="text" placeholder="What&apos;s your email?" class="email">
+<a class="register"></a>
+</div>
+<label style="display: block; opacity: 1;"><span></span>Please use a valid email</label>
+</li>
+<li style="display:none">
+<input type="hidden" name="elqFormName" id="elqFormName" value="WebsiteNewsletterSignup_new">
+</li>
+</ul>
+</form>
+<div class="l-island l-island-right social clear">
+<span itemscope itemtype="https://schema.org/Organization">
+<link itemprop="url" href="https://www.zendesk.com">
+<a itemprop="sameAs" href="//plus.google.com/+zendesk" class="ent-text ico-gplus" rel="publisher">&#59639;</a>
+<a itemprop="sameAs" href="//www.facebook.com/zendesk" class="ent-text ico-facebook">&#59636;</a>
+<a itemprop="sameAs" href="//www.twitter.com/zendesk" class="ent-text ico-twitter">&#59634;</a>
+<a itemprop="sameAs" href="//www.linkedin.com/company/zendesk" class="ent-text ico-linkedin">&#59645;</a>
+<a itemprop="sameAs" href="http://www.slideshare.net/zendesk" class="ent-text ico-slideshare"></a>
+<a itemprop="sameAs" href="//instagram.com/zendesk/" class="ent-text ico-instagram">&#59657;</a>
+</span>
+</div>
+</div>
+</div>
+<div class="clearfix"></div>
+</div>
+<div class="legal clear">
+<div class="col-960">
+<a href="//www.zendesk.com/company/customers-partners/#terms-of-use">Terms of Use</a>
+<a href="//www.zendesk.com/company/customers-partners/#privacy-policy">Privacy Policy</a>
+<a href="//www.zendesk.com/company/customers-partners/#cookie-policy">Cookie Policy</a>
+<a href="https://www.zendesk.com/legal/">&copy;Zendesk 2017</a>
+</div>
+</div>
+<div class="universe-search">
+<div class="universe-search-close ent-text"></div>
+<div class="col-960">
+<div class="universe-search-help"><span class="universe-search-help-count">0</span> results. <br/>How about another try?</div>
+<div class="universe-search-form">
+<span class="universe-search-icon ent-text"></span>
+<input type="text" name="search" class="universe-search-input" placeholder="Start typing to get your search on..." value=""/>
+</div>
+<div class="universe-search-results"></div>
+<div class="universe-search-pagination" style="display:none">
+<ol class="universe-search-pagination-list"> </ol>
+</div>
+</div>
+</div>
+<div class="search">
+<div class="col-960">
+<a href="javascript:;" class="search-launcher"><span class="ent-text icon"></span>Search Zendesk <span class="cursor"></span></a>
+</div>
+</div>
+<div class="clearfix"></div>
+</footer>
+
+<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" data-apikey="14b4da2b1698aa9ce8da80a183366f26"></script>
+<script type="text/javascript" src="//api.demandbase.com/api/v2/ip.js?key=cb334198e711721abab9b3d4c785e482544ca07f&var=dbase"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/plugins.min.b8103b49.js"></script><script src="https://d1eipm3vz40hy0.cloudfront.net/js/webutils.min.d107191a.js"></script>
+<script src="https://d1eipm3vz40hy0.cloudfront.net/js/global.min.04c36daa.js"></script>
+
+<script type="text/javascript">
+  webutils.styleHeader();
+  webutils.gauge();
+
+  var emeaCountryCodes = new Array('UK', 'GB', 'IM', 'GI', 'JE', 'GG', 'AT', 'BE', 'CY', 'EE', 'FI', 'FR', 'DE', 'EL', 'IE', 'IT', 'LV', 'LU', 'MT', 'NL', 'PT', 'SK', 'SI', 'ES', 'MC', 'VA', 'SM', 'ME', 'MC', 'LU', 'XK', 'KV', 'GR', 'AD')
+    , emeaDomainNames  = new Array('www.zendesk.de', 'www.zendesk.es', 'www.zendesk.fr', 'www.zendesk.it', 'www.zendesk.nl');
+
+  if((typeof dbase !== 'undefined' && $.inArray(dbase.registry_country_code, emeaCountryCodes) > -1) || $.inArray(window.location.hostname, emeaDomainNames) > -1) {
+    webutils.cookieNotice();
+  }
+
+  webutils.loadEloqua();
+</script>
+<script type="text/javascript">
+  dataLayer = [];
+</script>
+
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-Z4DV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+<script>
+  if (!window.potentialBot) {
+    webutils.loadGTM();
+    webutils.processGA();
+    webutils.saveEloquaGuid();
+  }
+</script>
+<script type="text/javascript">
+  $(document).ready(function(){
+    webutils.lockTopNavigation(); // make top navigation sticky
+
+    var animationHelpers = {
+      appearDone: function(e) {
+        $(e.currentTarget)
+          .addClass("entrance-done")
+          .off("animationend", animationHelpers.appearDone)
+          .on("animationend", animationHelpers.hoverState);
+        $(e.currentTarget).parent()
+          .on("mouseover", animationHelpers.mouseOver);
+      },
+      hoverState: function(e) {
+        $(e.currentTarget).removeClass("hover");
+      },
+      mouseOver: function(e){
+        $(e.currentTarget).children(".feature-icon-common").addClass("hover");
+      },
+      curtainUp: function(e) {
+        var curtainCall = animationHelpers.$family.offset().top;
+        var windowOffset   = window.pageYOffset + window.innerHeight;
+
+        if (curtainCall < windowOffset) {
+          animationHelpers.$family.addClass("curtain-up");
+          $(window).off("scroll", animationHelpers.curtainUp);
+        }
+      },
+      $family: $(".zendesk-family-products")
+    }
+
+    $(".product-link").children(".feature-icon-common").on("animationend", animationHelpers.appearDone);
+
+    if (!_isMobile) {
+      document.getElementById("hero-video").play();
+    }
+    $(window).scroll(animationHelpers.curtainUp);
+    animationHelpers.curtainUp();
+
+  });
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
/cc @zendesk/secdev @ggrossman 

### Description
Ticket https://support.zendesk.com/agent/tickets/2139072 pointed out that it is possible to use a number as a string class in an html tag and that if this is redacted we have a problem.
This code allows us to opt into the regular expression solution to not redact numbers within the html tags.

To test you will need to send in the option exclude_html_tags: true  
This gives us arturo control over this new redaction feature.

### References
* JIRA: https://zendesk.atlassian.net/browse/SECDEV-1579

### Risks
* [medium] will no longer redact credit card numbers inside <> with some letters in there.
