### PR TITLE
change credit card number regex for VISA to accept 19 digits

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizer
 
   # https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18
   CARD_COMPANIES = {
-    'visa'               => /^4\d{12}(\d{3})?$/,
+    'visa'               => /^4\d{12}(\d{3})?(\d{3})?$/,
     'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
     'discover'           => /^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/,
     'american_express'   => /^3[47]\d{13}$/,


### PR DESCRIPTION
https://github.com/activemerchant/active_merchant/pull/1659