### PR TITLE
[ZD2818150] - Exclude Acquirer Reference Numbers

### DIFF
--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -149,6 +149,10 @@ describe CreditCardSanitizer do
       assert_nil @sanitizer.sanitize!('4111:1111:1111:1111')
     end
 
+    it 'does not sanitize ARN numbers' do
+      assert_nil @sanitizer.sanitize!('74537606287640125960797 and 74537606281640124230958')
+    end
+
     it 'does not sanitize credit card numbers that are part of a url' do
       assert_nil @sanitizer.sanitize!('http://support.zendesk.com/tickets/4111111111111111')
       assert_nil @sanitizer.sanitize!('blah blah  http://support.zendesk.com/tickets/4111111111111111.json')


### PR DESCRIPTION
### Description
ARM Numbers should not be redacted when Credit Card Redaction feature is turned on, numbers are incorrectly redacted by Credit Card Redaction feature.

https://www.quora.com/What-is-an-ARN-number-and-how-to-track-my-transaction-with-that-number

**Note:**
This is just a PoC, I dont know much about ARNs only pattern that found around some public code was that they follow 23 numbers and in this specific case all started with 7 but that might not be right...

```
zendesk(dev)> credit_card_sanitizer.sanitize!("74537606281640124230958 and 74537606287640125960797", {})
=> "745376▇▇▇▇▇▇▇▇▇▇▇▇▇0958 and 745376▇▇▇▇▇▇▇▇▇▇▇▇▇0797"
```
@zendesk/sustaining  @ggrossman 

### Steps to reproduce
```
include Zendesk::CreditCardRedaction
credit_card_sanitizer.sanitize!("74537606281640124230958 and 74537606287640125960797", {})`
```

### Steps to merge
 - [ ] :+1: 
 
 
### Related PRs
https://support.zendesk.com/agent/tickets/2818150

### Risks
[Low] once release this can be controlled behind an arturo setting the flag exclude_acquierer_reference_number option to false (true by default in the gem).  This would just redact wrong numbers in case of something going wrong.  Numbers only.