### PR TITLE
[ZD#2818150] exclude arn numbers

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -9,7 +9,7 @@ class CreditCardSanitizer
   CARD_COMPANIES = {
     'visa'               => /^4\d{12}(\d{3})?(\d{3})?$/,
     'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
-    'discover'           => /^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/,
+    'discover'           => /^((6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14}))$/,
     'american_express'   => /^3[47]\d{13}$/,
     'diners_club'        => /^3(0[0-5]|[68]\d)\d{11}$/,
     'jcb'                => /^35(28|29|[3-8]\d)\d{12}$/,

--- a/scripts/generate_card.rb
+++ b/scripts/generate_card.rb
@@ -1,0 +1,51 @@
+require 'bundler/setup'
+require 'credit_card_sanitizer'
+
+# Generates a random card of a specified type that passes
+# a Luhn checksum.
+def self.generate_card(type:, count: 1)
+  [].tap do |numbers|
+    while numbers.length < count
+      candidate = generate_card_candiate(type: type)
+      numbers << candidate if LuhnChecksum.valid?(candidate)
+    end
+  end
+end
+
+# The formats for each card type are from the
+# CreditCardSanitizer::CARD_COMPANIES regexs
+def self.generate_card_candiate(type:)
+  case type
+  when :visa
+    digits = [4] + Array.new(14) { Random.rand(10) }
+  when :jcb
+    digits = [3528] + Array.new(11) { Random.rand(10) }
+  when :switch
+    digits = [6759] + Array.new(11) { Random.rand(10) }
+  when :solo
+    digits = [6767] + Array.new(11) { Random.rand(10) }
+  when :forbrugsforeningen
+    digits = [600722] + Array.new(9) { Random.rand(10) }
+  when :laser
+    digits = [6304] + Array.new(7) { Random.rand(10) }
+  else
+    raise "unhandled type: #{type}"
+  end
+
+  total = 0
+  digits.reverse.each_with_index do |x, i|
+    x *= 3 if i.even?
+    total += x
+  end
+  check = total % 10
+  check = (10 - check) unless check.zero?
+  (digits + [check]).join
+end
+
+type = ARGV.first
+
+if type
+  puts generate_card(type: ARGV.first.to_sym)
+else
+  puts 'type not specified: ruby scripts/generate_card.rb visa'
+end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -356,6 +356,10 @@ describe CreditCardSanitizer do
           assert_nil @sanitizer.sanitize!('Hello 67 999901000 00000 019 there')
           assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
         end
+
+        it 'does not sanitize ARN numbers' do
+          assert_nil @sanitizer.sanitize!('74537606287640125960797 and 74537606281640124230958')
+        end
       end
     end
   end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -357,6 +357,55 @@ describe CreditCardSanitizer do
           assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
         end
 
+        # these numbers were generated via scripts/generate_card.rb
+        it 'does not santitize a visa credit card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('04881621594644972')
+        end
+
+        it 'does not santitize a mastercard number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('05555555555554444')
+        end
+
+        it 'does not santitize a discover card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('06011000000000000')
+        end
+
+        it 'does not santitize an amex number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('0378282246310005')
+        end
+
+        it 'does not santitize a diners club number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('030569309025904')
+        end
+
+        it 'does not santitize a jcb card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('03528154373040254')
+        end
+
+        it 'does not santitize a switch number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('06759982158418979')
+        end
+
+        it 'does not santitize a solo card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('06767859394986987')
+        end
+
+        it 'does not santitize a dankort card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('05019717010103742')
+        end
+
+        it 'does not santitize a maestro card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('06799990100000000019')
+        end
+
+        it 'does not santitize a forbrugsforeningen card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('06007228728677953')
+        end
+
+        it 'does not santitize a laser card number embedded in a number' do
+          assert_nil @sanitizer.sanitize!('0630487115747')
+        end
+
         it 'does not sanitize ARN numbers' do
           assert_nil @sanitizer.sanitize!('74537606287640125960797 and 74537606281640124230958')
         end


### PR DESCRIPTION
@zendesk/secdev  @miketineo 

This is an alternative fix for #45

It looks like ARN numbers are matching due to an oversight in the discover regex where the anchor is only being applied to the first set of groupings. 

@ggrossman The anchor should apply to all the sets right? 

## References
https://support.zendesk.com/agent/tickets/2818150

## Risks
Low: valid discover credit card numbers aren't redacted. 