### PR TITLE
[ZD#3223512] Support Mastercard 2-series BINs

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizer
   # https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18
   CARD_COMPANIES = {
     'visa'               => /^4\d{12}(\d{3})?(\d{3})?$/,
-    'master'             => /^(5[1-5]\d{4}|677189)\d{10}$/,
+    'master'             => /^(5[1-5]\d{4}|677189|222[1-9]\d{2}|22[3-9]\d{3}|2[3-6]\d{4}|27[01]\d{3}|2720\d{2})\d{10}$/,
     'discover'           => /^((6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14}))$/,
     'american_express'   => /^3[47]\d{13}$/,
     'diners_club'        => /^3(0[0-5]|[68]\d)\d{11}$/,

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -55,7 +55,7 @@ describe CreditCardSanitizer do
     end
 
     it 'sanitizes lots of random MasterCard cards' do
-      ['51', '52', '53', '54', '55', '677189'].each do |prefix|
+      ['2221', '23', '26', '270', '271', '2720', '51', '52', '53', '54', '55', '677189'].each do |prefix|
         10000.times do
           candidate = Luhnacy.generate(16, prefix: prefix)
           assert_equal candidate[0..5] + '▇▇▇▇▇▇' + candidate[12..-1], @sanitizer.sanitize!(candidate)


### PR DESCRIPTION
### Description

Since 2017, Mastercard have a new series of BINs starting with 2: https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html

This change updates the `master` regex to support this range, similar to https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L7

### References
z1: https://support.zendesk.com/agent/tickets/3223512

@zendesk/sustaining @zendesk/secdev 

