### PR TITLE
[ZD#3223512] Allow cards followed by whitespace + expiration to be redacted

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -203,7 +203,10 @@ class CreditCardSanitizer
 
   def without_expiration(text)
     expiration_date_boundary = SecureRandom.hex.tr('0123456789', 'ABCDEFGHIJ')
-    text.gsub!(EXPIRATION_DATE) { |expiration_date| "#{expiration_date_boundary}#{expiration_date}#{expiration_date_boundary}" }
+    text.gsub!(EXPIRATION_DATE) do |expiration_date|
+      match = expiration_date.match(/(?<whitespace>\s*)(?<rest>.*)/)
+      "#{match[:whitespace]}#{expiration_date_boundary}#{match[:rest]}#{expiration_date_boundary}"
+    end
     yield
     text.gsub!(expiration_date_boundary, '')
   end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -16,7 +16,7 @@ describe CreditCardSanitizer do
   end
 
   before do
-    @sanitizer = CreditCardSanitizer.new
+    @sanitizer = CreditCardSanitizer.new(parse_flanking: true)
   end
 
   describe 'credit card patterns' do
@@ -204,7 +204,7 @@ describe CreditCardSanitizer do
     describe 'parse_flanking option' do
       describe 'when false' do
         before do
-          refute @sanitizer.settings[:parse_flanking]
+          @sanitizer = CreditCardSanitizer.new(parse_flanking: false)
         end
 
         it 'sanitizes credit card number prefixed by CREDIT CARD' do
@@ -239,6 +239,14 @@ describe CreditCardSanitizer do
 
         it 'sanitizes credit card numbers followed by a ex' do
           assert_equal 'creditcard 4111 11▇▇ ▇▇▇▇ 1111exp06/17', @sanitizer.sanitize!('creditcard 4111 1111 1111 1111exp06/17')
+        end
+
+        it 'sanitizes numbers followed by a newline and expiry' do
+          assert_equal "creditcard 4111 11▇▇ ▇▇▇▇ 1111\n06/17", @sanitizer.sanitize!("creditcard 4111 1111 1111 1111\n06/17")
+        end
+
+        it 'sanitizes numbers followed by a newline and random string' do
+          assert_equal "creditcard 4111 11▇▇ ▇▇▇▇ 1111\nasdfasdf", @sanitizer.sanitize!("creditcard 4111 1111 1111 1111\nasdfasdf")
         end
 
         it 'does not sanitize credit card numbers flanked by letters' do


### PR DESCRIPTION
### Description

Since https://github.com/zendesk/credit_card_sanitizer/pull/43, strings of the form `<card_number><whitespace><expiration_date>` where `<expiration_date>` matches regex `EXPIRATION_DATE` result in the card number not being redacted. This is due to `without_expiration` wrapping `<whitespace><expiration_date>` (i.e. including leading whitespace) in a random string, which causes `valid_postfix?` to fail due to `!ALPHANUMERIC.match(postfix[0])`. As the postfix is not valid, redaction does not occur.

This change moves `<whitespace>` outside of the wrapping in `without_expiration`, so that `valid_postfix?` will subsequently succeed.

This also changes the bottom level `before` block in the tests to create a sanitizer with `parse_flanking: true`. This is due to tests on lines 188-201 which (it appears) should pass even with `parse_flanking: true`.

#### Current behaviour

```
zendesk(dev)> c = CreditCardSanitizer.new(parse_flanking: true)
=> #<CreditCardSanitizer:0x007f4053273180 @settings={:replacement_token=>"▇", :expose_first=>6, :expose_last=>4, :use_groupings=>false, :exclude_tracking_numbers=>false, :parse_flanking=>true}>
zendesk(dev)> t = "4111111111111111\n01/20"
=> "4111111111111111\n01/20"
zendesk(dev)> c.sanitize! t
=> nil
zendesk(dev)> d = CreditCardSanitizer.new(parse_flanking: false)
=> #<CreditCardSanitizer:0x007f40532ea2d0 @settings={:replacement_token=>"▇", :expose_first=>6, :expose_last=>4, :use_groupings=>false, :exclude_tracking_numbers=>false, :parse_flanking=>false}>
zendesk(dev)> d.sanitize! t
=> "411111▇▇▇▇▇▇1111\n01/20"
```
```
zendesk(dev)> s = CreditCardSanitizer.new(parse_flanking: true)
=> #<CreditCardSanitizer:0x007f80a239b690 @settings={:replacement_token=>"▇", :expose_first=>6, :expose_last=>4, :use_groupings=>false, :exclude_tracking_numbers=>false, :parse_flanking=>true}>
zendesk(dev)> num_with_exp = "4111111111111111 01/20"
=> "4111111111111111 01/20"
zendesk(dev)> num_without_exp = "4111111111111111 a01/20"
=> "4111111111111111 a01/20"
zendesk(dev)> s.sanitize! num_with_exp
=> nil
zendesk(dev)> s.sanitize! num_without_exp
=> "411111▇▇▇▇▇▇1111 a01/20"
```

#### New behaviour

The calls to `sanitize!` returning nil above should succeed and redact the card numbers correctly.

### Other notes

I looked at https://support.zendesk.com/agent/tickets/2598784 which led to https://github.com/zendesk/credit_card_sanitizer/pull/43 and it seems like this PR won't have a negative effect with respect to the intention of https://github.com/zendesk/credit_card_sanitizer/pull/43.

### References

z1: https://support.zendesk.com/agent/tickets/3223512
Previous related PR: https://github.com/zendesk/credit_card_sanitizer/pull/43

@zendesk/sustaining @zendesk/secdev @lisacf @ggrossman 
