### PR TITLE
Fix whitespace being lost at end of matching group

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -204,7 +204,7 @@ class CreditCardSanitizer
   def without_expiration(text)
     expiration_date_boundary = SecureRandom.hex.tr('0123456789', 'ABCDEFGHIJ')
     text.gsub!(EXPIRATION_DATE) do |expiration_date|
-      match = expiration_date.match(/(?<whitespace>\s*)(?<rest>.*)/)
+      match = expiration_date.match(/(?<whitespace>\s*)(?<rest>.*)/m)
       "#{match[:whitespace]}#{expiration_date_boundary}#{match[:rest]}#{expiration_date_boundary}"
     end
     yield

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -241,8 +241,8 @@ describe CreditCardSanitizer do
           assert_equal 'creditcard 4111 11▇▇ ▇▇▇▇ 1111exp06/17', @sanitizer.sanitize!('creditcard 4111 1111 1111 1111exp06/17')
         end
 
-        it 'sanitizes numbers followed by a newline and expiry' do
-          assert_equal "creditcard 4111 11▇▇ ▇▇▇▇ 1111\n06/17", @sanitizer.sanitize!("creditcard 4111 1111 1111 1111\n06/17")
+        it 'sanitizes numbers followed by a newline, expiry, and another newline' do
+          assert_equal "creditcard 4111 11▇▇ ▇▇▇▇ 1111\n06/17\n111", @sanitizer.sanitize!("creditcard 4111 1111 1111 1111\n06/17\n111")
         end
 
         it 'sanitizes numbers followed by a newline and random string' do


### PR DESCRIPTION
### Description

A bug was introduced in https://github.com/zendesk/credit_card_sanitizer/pull/49 where trailing whitespace was being discarded on expiration date matching. This change captures the trailing whitespace and retains it.

### References
* z1: https://support.zendesk.com/agent/tickets/3223512

@zendesk/sustaining @zendesk/secdev @ggrossman 