### PR TITLE
Don't sanitize numeric sequences found within relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Turning on this option reduces the likelihood of a tracking number being identif
 and truncated. However, it runs the risk of an actual credit card number being incorrectly identified as
 a shipping tracking number, and not truncated.
 
+### Exclusion of URLs and phone numbers
+
+Phone numbers and numeric IDs in URLs sometimes resemble credit card numbers and pass Luhn checksum.
+The gem tries to avoid sanitizing these by scanning for these types of strings in text:
+
+  * Leading `+`, which often precedes the country code in a phone number
+  * Leading `/`, which precedes a relative URL
+  * The protocol and `://` in an absolute URL, such as `https://`
+
+The gem works by scanning through blocks of text using a regular expression that matches numeric
+sequences. The regular expression also matches the above-mentioned patterns. The idea is that the captured
+text will include the prefix, instead of just being the numeric sequence itself. If the prefix is present
+in the captured text, the numeric sequence won't be sanitized. Numeric sequences are only sanitized
+if they're captured on their own.
+
 ### Rails filtering parameters
 
 The `#parameter_filter` is meant to be used with `ActionDispatch` to automatically truncate PANs

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -44,7 +44,7 @@ class CreditCardSanitizer
   LINE_NOISE_CHAR = /[^\w\n,()&.\/:;<>]/
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
-  SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):[^\s>]+)/
+  SCHEME_OR_PLUS = /((?:&#43;|\+|\/)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):[^\s>]+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,30}/
 
   DEFAULT_OPTIONS = {

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -167,6 +167,14 @@ describe CreditCardSanitizer do
       assert_nil @sanitizer.sanitize!('(+4111111111111111)')
     end
 
+    it 'does not sanitize relative URLs containing numbers' do
+      assert_nil @sanitizer.sanitize!('/knowledge/articles/4402126792468/en-us')
+    end
+
+    it 'does not sanitize relative URLs embedded within HTML text' do
+      assert_nil @sanitizer.sanitize!('<div style=\"padding:8px 8px 8px 20px\"><a style=\"vertical-align:middle\" href=\"/knowledge/articles/4402126792468/en-us\">Edit article</a><ul class=\"guide-markup\"><li class=\"guide-markup\">Search the Help Center without leaving the ticket</li><li class=\"guide-markup\">Insert links to relevant Help Center articles in ticket comments</li><li class=\"guide-markup\">Add inline feedback to existing articles that need updates</li><li class=\"guide-markup\">Create new articles while answering tickets using a pre-defined template</li></ul></div>')
+    end
+
     it 'does not sanitize numbers that include a numeric html entity' do
       assert_nil @sanitizer.sanitize!('&#43; 1 936 321 1111')
     end


### PR DESCRIPTION
Add forward slash to the `SCHEME_OR_PLUS` pattern so that credit card-like numbers found within relative URLs are not redacted.

@zendesk-kevinramirez 