### PR TITLE
Add return_changes option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,9 @@ GEM
     ast (2.3.0)
     bump (0.5.4)
     byebug (9.0.6)
+    io-console (0.5.6)
+    irb (1.2.6)
+      reline (>= 0.1.5)
     luhn_checksum (0.1.1)
     luhnacy (0.2.1)
     maxitest (2.4.0)
@@ -23,6 +26,8 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
+    reline (0.1.5)
+      io-console (~> 0.5)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -44,6 +49,7 @@ DEPENDENCIES
   bundler
   byebug
   credit_card_sanitizer!
+  irb
   luhnacy
   maxitest
   rake

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ if they're captured on their own.
 ### `return_changes` option
 
 As mentioned above, the return value of `sanitize!` is similar to `String#gsub!`: The modified string
-is returned, if changes were made, otherwise `nil` is returned.
+is returned, if changes were made; otherwise, `nil` is returned.
 
 The `return_changes` option alters the behavior of `sanitize!` to return an array of the individual credit
 card numbers that were found, and the redacted versions they were replaced with:
 
-```
+```ruby
 irb(main):004:0> sanitizer=CreditCardSanitizer.new(return_changes:true)
 => #<CreditCardSanitizer:0x000000013791f108 @settings={:replacement_token=>...
 irb(main):005:0> sanitizer.sanitize!('Hello 4111 1111 1111 1111 there and hello 
@@ -138,7 +138,7 @@ irb(main):006:0>
 
 Note that `sanitize!` still returns `nil` if nothing was changed, even with the `return_changes` option.
 
-```
+```ruby
 irb(main):006:0> sanitizer.sanitize!('foo bar')
 => nil
 ```
@@ -148,7 +148,7 @@ irb(main):006:0> sanitizer.sanitize!('foo bar')
 The `#parameter_filter` is meant to be used with `ActionDispatch` to automatically truncate PANs
 found in Rails parameters that are to be logged, before the logs are flushed to disk.
 
-```Ruby
+```ruby
 Rails.app.config.filter_parameters = [:password, CreditCardSanitizer.parameter_filter]
 
 env = {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Name                       | Description
 `expose_last`              | The number of trailing digits of the credit card number to leave intact. The default is `4`.
 `use_groupings`            | Use known card number groupings to reduce false positives. The default is `false`.
 `exclude_tracking_numbers` | Identify shipping tracking numbers and don't truncate them. The default is `false`.
+`return_changes`           | When `true`, `sanitize!` returns a list of redactions made. The default is `false`.
 
 ### Default Replacement Level
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,20 @@ are "sanitized" by replacing some or all of the digits with a replacement charac
 process is referred to as _truncation_, and the result is referred to as a
 [truncated Primary Account Number (PAN)](https://pcissc.secure.force.com/faq/articles/Frequently_Asked_Question/Are-truncated-Primary-Account-Numbers-PAN-required-to-be-protected-in-accordance-with-PCI-DSS).
 
-Example:
+### Basic Usage
+
+The main entry point is `CreditCardSanitizer#sanitize!`. This will perform sanitization of a string in-place,
+much like `String#gsub!` does for substring replacement.
 
 ```ruby
 text = "Hello my card is 4111 1111 1111 1111  maybe you should not store that in your database!"
 CreditCardSanitizer.new(replacement_character: '▇').sanitize!(text)
 text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not store that in your database!"
 ```
+
+The return value of `sanitize!` is similar to `String#gsub!`: If no changes are made to the input string,
+`nil` is returned. If any changes were made, the string is modified in-place, but the resulting string
+is also returned.
 
 ### Configuration
 
@@ -111,6 +118,30 @@ sequences. The regular expression also matches the above-mentioned patterns. The
 text will include the prefix, instead of just being the numeric sequence itself. If the prefix is present
 in the captured text, the numeric sequence won't be sanitized. Numeric sequences are only sanitized
 if they're captured on their own.
+
+### `return_changes` option
+
+As mentioned above, the return value of `sanitize!` is similar to `String#gsub!`: The modified string
+is returned, if changes were made, otherwise `nil` is returned.
+
+The `return_changes` option alters the behavior of `sanitize!` to return an array of the individual credit
+card numbers that were found, and the redacted versions they were replaced with:
+
+```
+irb(main):004:0> sanitizer=CreditCardSanitizer.new(return_changes:true)
+=> #<CreditCardSanitizer:0x000000013791f108 @settings={:replacement_token=>...
+irb(main):005:0> sanitizer.sanitize!('Hello 4111 1111 1111 1111 there and hello 
+3782 822463 10005 there')
+=> [["4111 1111 1111 1111", "4111 11▇▇ ▇▇▇▇ 1111"], ["3782 822463 10005", "3782 82▇▇▇▇ ▇0005"]]
+irb(main):006:0> 
+```
+
+Note that `sanitize!` still returns `nil` if nothing was changed, even with the `return_changes` option.
+
+```
+irb(main):006:0> sanitizer.sanitize!('foo bar')
+=> nil
+```
 
 ### Rails filtering parameters
 

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new 'credit_card_sanitizer', '0.6.9' do |gem|
   gem.license       = 'Apache License Version 2.0'
   gem.files         = `git ls-files lib`.split($\)
 
+  gem.add_development_dependency('irb')
   gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
   gem.add_runtime_dependency('tracking_number', '~> 0.10.3')
 end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -427,6 +427,40 @@ describe CreditCardSanitizer do
         end
       end
     end
+
+    describe 'return_changes' do
+      describe 'return_changes is false' do
+        before do
+          refute @sanitizer.settings[:return_changes]
+        end
+
+        it 'returns nil when no sanitization performed' do
+          assert_nil @sanitizer.sanitize!('Hello 4xxx 1111 1111 1111 there')
+        end
+
+        it 'returns redacted text when sanitization performed' do
+          assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        end
+      end
+
+      describe 'return_changes is true' do
+        before do
+          @sanitizer = CreditCardSanitizer.new(return_changes: true)
+        end
+
+        it 'returns nil when no sanitization performed' do
+          assert_nil @sanitizer.sanitize!('Hello 4xxx 1111 1111 1111 there')
+        end
+
+        it 'returns list of changes when sanitization performed' do
+          assert_equal [['4111 1111 1111 1111', '4111 11▇▇ ▇▇▇▇ 1111']], @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        end
+
+        it 'returns list of multiple changes' do
+          assert_equal [['4111 1111 1111 1111', '4111 11▇▇ ▇▇▇▇ 1111'], ['3782 822463 10005', '3782 82▇▇▇▇ ▇0005']], @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there and hello 3782 822463 10005 there')
+        end
+      end
+    end
   end
 
   describe '#parameter_filter' do


### PR DESCRIPTION
This adds a new option to the sanitizer, `return_changes`.

Currently, the `sanitize!` method behaves like `gsub!`:
 * When changes are made, the updated string is returned. 
 * When no changes are made, `nil` is returned.

When `return_changes` is `true`, the `sanitize!` method will instead return:
 * When changes are made, an array of `[old_text, new_text]` containing the substitution that was made for each redacted credit card number.
 * When no changes are made, `nil` is returned.
