### PR TITLE
Fix: Possible ReDos in sanitize! method of CreditCardSanitizer class

### DIFF
--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -33,6 +33,8 @@ class CreditCardSanitizer
     "forbrugsforeningen" => [[4, 4, 4, 4]],
     "laser" => [[4, 4, 4, 4]]
   }.freeze
+  
+  SAFE_CHAR_LENGTH = 10000
 
   ACCEPTED_PREFIX = /(?:cc|card|visa|amex)\z/i
   ACCEPTED_POSTFIX = /\Aex/i
@@ -92,6 +94,8 @@ class CreditCardSanitizer
   # If options[:return_changes] is true, returns nil if no redaction happened,
   # else an array of [old_text, new_text] indicating what substrings were redacted.
   def sanitize!(text, options = {})
+    return nil if text.lenght > SAFE_CHAR_LENGTH
+
     options = @settings.merge(options)
 
     text.force_encoding(Encoding::UTF_8)


### PR DESCRIPTION
Issue: https://github.com/zendesk/credit_card_sanitizer/issues/65
CreditCardSanitizer.new.sanitize!("aa"*10000000000) will cause the system to hang due to slow Regex.

Fix:
Add SAFE_CHAR_LENGTH for sanitize text