### PR TITLE
Use debug instead of byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "byebug"
+gem "debug", ">= 1.9.2", require: ["debug/prelude", "debug/config"]
 gem "luhnacy"
 gem "maxitest"
 gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem "bump"
-gem "bundler"
 gem "byebug"
 gem "luhnacy"
 gem "maxitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    bump (0.10.0)
     byebug (11.1.3)
     io-console (0.7.2)
     irb (1.12.0)
@@ -76,8 +75,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bump
-  bundler
   byebug
   credit_card_sanitizer!
   irb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    byebug (11.1.3)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -72,12 +74,12 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-22
   ruby
 
 DEPENDENCIES
-  byebug
   credit_card_sanitizer!
-  irb
+  debug (>= 1.9.2)
   luhnacy
   maxitest
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "bundler/gem_tasks"
-require "bump/tasks"
 require "rake/testtask"
 require "standard/rake"
 

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new "credit_card_sanitizer", "0.7.0" do |gem|
   gem.license = "Apache License Version 2.0"
   gem.files = `git ls-files lib`.split($\)
 
-  gem.add_development_dependency("irb")
   gem.add_runtime_dependency("luhn_checksum", "~> 0.1")
   gem.add_runtime_dependency("tracking_number", "~> 0.10.3")
 end


### PR DESCRIPTION
Use a newer, more modern debugger.

We recommend adding the following configuration file `~/.rdbgrc`:
```
config set irb_console 1
config set use_short_path 1
```

This PR also removes unnecessary depencency `bump` and an unnecessary mention of `bundler` inside Gemfile.