### PR TITLE
[DDEL-629] Update sanitization regexes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.7.1)
+    credit_card_sanitizer (1.0.0)
       luhn_checksum (~> 0.1)
       tracking_number (~> 0.10.3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.7.0)
+    credit_card_sanitizer (0.7.1)
       luhn_checksum (~> 0.1)
       tracking_number (~> 0.10.3)
 

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", "0.7.0" do |gem|
+Gem::Specification.new "credit_card_sanitizer", "0.7.1" do |gem|
   gem.authors = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email = ["ggrossman@zendesk.com"]
   gem.description = "Credit card sanitizer"

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", "0.7.1" do |gem|
+Gem::Specification.new "credit_card_sanitizer", "1.0.0" do |gem|
   gem.authors = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email = ["ggrossman@zendesk.com"]
   gem.description = "Credit card sanitizer"

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -3,7 +3,6 @@ require "securerandom"
 require "tracking_number"
 
 class CreditCardSanitizer
-  # https://github.com/activemerchant/active_merchant/blob/e282efb447bf20688254301fda0534d6201f97f1/lib/active_merchant/billing/credit_card_methods.rb#L7-L58
   CARD_COMPANIES = {
     "visa" => /^4\d{12}(\d{3})?(\d{3})?$/,
     "master" => /^(5[1-5]\d{4}|677189|222[1-9]\d{2}|22[3-9]\d{3}|2[3-6]\d{4}|27[01]\d{3}|2720\d{2})\d{10}$/,
@@ -16,7 +15,13 @@ class CreditCardSanitizer
     "dankort" => /^5019\d{12}$/,
     "maestro" => /^(5[06-8]\d{10,17}|6\d\d{10,17}|5018|5020|5038|5893|6304|6759|6761|6762|6763\d{8,15})$/,
     "forbrugsforeningen" => /^600722\d{10}$/,
-    "laser" => /^(6304|6706|6709|6771(?!89))(\d{12,15}|\d{8}(\d{4}|\d{6,7})?)$/
+    "laser" => /^(6304|6706|6709|6771(?!89))(\d{12,15}|\d{8}(\d{4}|\d{6,7})?)$/,
+    "bc_global" => /^(6541|6556)\d{12}$/,
+    "carte_blanche" => /^389\d{11}$/,
+    "insta_payment" => /^63[7-9]\d{13}$/,
+    "korean_local" => /^9\d{15}$/,
+    "union_pay" => /^62\d{14,17}$/,
+    "visa_master" => /^(4\d{12}(\d{3})?|5[1-5]\d{14})$/
   }.freeze
 
   CARD_NUMBER_GROUPINGS = {
@@ -31,7 +36,13 @@ class CreditCardSanitizer
     "dankort" => [[4, 4, 4, 4]],
     "maestro" => [[4], [5], [4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]],
     "forbrugsforeningen" => [[4, 4, 4, 4]],
-    "laser" => [[4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]]
+    "laser" => [[4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]],
+    "bc_global" => [[4, 4, 4, 4]],
+    "carte_blanche" => [[4, 6, 4]],
+    "insta_payment" => [[4, 4, 4, 4]],
+    "korean_local" => [[4, 4, 4, 4]],
+    "union_pay" => [[4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]],
+    "visa_master" => [[4, 4, 4, 4], [4, 4, 4, 4, 3]]
   }.freeze
 
   ACCEPTED_PREFIX = /(?:cc|card|visa|amex)\z/i

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -3,20 +3,20 @@ require "securerandom"
 require "tracking_number"
 
 class CreditCardSanitizer
-  # https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18
+  # https://github.com/activemerchant/active_merchant/blob/e282efb447bf20688254301fda0534d6201f97f1/lib/active_merchant/billing/credit_card_methods.rb#L7-L58
   CARD_COMPANIES = {
     "visa" => /^4\d{12}(\d{3})?(\d{3})?$/,
     "master" => /^(5[1-5]\d{4}|677189|222[1-9]\d{2}|22[3-9]\d{3}|2[3-6]\d{4}|27[01]\d{3}|2720\d{2})\d{10}$/,
-    "discover" => /^((6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14}))$/,
+    "discover" => /^((6011\d{12})|(65[4-9]\d{13})|(64[4-9]\d{13})|(622(?:12[6-9]|1[3-9]\d|[2-8]\d{2}|9[01]\d|92[0-5])\d{10}))$/,
     "american_express" => /^3[47]\d{13}$/,
     "diners_club" => /^3(0[0-5]|[68]\d)\d{11}$/,
     "jcb" => /^35(28|29|[3-8]\d)\d{12}$/,
-    "switch" => /^6759\d{12}(\d{2,3})?$/,
-    "solo" => /^6767\d{12}(\d{2,3})?$/,
+    "switch" => /^(6759\d{12}(\d{2,3})?|(4903|4905|4911|4936|6333|6759)\d{12}|(4903|4905|4911|4936|6333|6759)\d{14}|(4903|4905|4911|4936|6333|6759)\d{15}|564182\d{10}|564182\d{12}|564182\d{13}|633110\d{10}|633110\d{12}|633110\d{13})$/,
+    "solo" => /^(6767\d{12}(\d{2,3})?|6334\d{12}|6334\d{14}|6334\d{15}|6767\d{14}|6767\d{15})$/,
     "dankort" => /^5019\d{12}$/,
-    "maestro" => /^(5[06-8]|6\d)\d{10,17}$/,
+    "maestro" => /^(5[06-8]\d{10,17}|6\d\d{10,17}|5018|5020|5038|5893|6304|6759|6761|6762|6763\d{8,15})$/,
     "forbrugsforeningen" => /^600722\d{10}$/,
-    "laser" => /^(6304|6706|6709|6771(?!89))\d{8}(\d{4}|\d{6,7})?$/
+    "laser" => /^(6304|6706|6709|6771(?!89))(\d{12,15}|\d{8}(\d{4}|\d{6,7})?)$/
   }.freeze
 
   CARD_NUMBER_GROUPINGS = {
@@ -27,11 +27,11 @@ class CreditCardSanitizer
     "diners_club" => [[4, 6, 4]],
     "jcb" => [[4, 4, 4, 4]],
     "switch" => [[4, 4, 4, 4]],
-    "solo" => [[4, 4, 4, 4]],
+    "solo" => [[4, 4, 4, 4], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]],
     "dankort" => [[4, 4, 4, 4]],
-    "maestro" => [[4], [5]],
+    "maestro" => [[4], [5], [4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]],
     "forbrugsforeningen" => [[4, 4, 4, 4]],
-    "laser" => [[4, 4, 4, 4]]
+    "laser" => [[4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]]
   }.freeze
 
   ACCEPTED_PREFIX = /(?:cc|card|visa|amex)\z/i

--- a/scripts/generate_card.rb
+++ b/scripts/generate_card.rb
@@ -28,6 +28,20 @@ def self.generate_card_candiate(type:)
     digits = [600722] + Array.new(9) { Random.rand(10) }
   when :laser
     digits = [6304] + Array.new(7) { Random.rand(10) }
+  when :bc_global
+    digits = [6541] + Array.new(11) { Random.rand(10) }
+  when :carte_blanche
+    digits = [389] + Array.new(10) { Random.rand(10) }
+  when :insta_payment
+    digits = [637] + Array.new(12) { Random.rand(10) }
+  when :korean_local
+    digits = [9] + Array.new(14) { Random.rand(10) }
+  when :union_pay
+    length = rand(13..16)
+    digits = [62] + Array.new(length) { Random.rand(10) }
+  when :visa_master
+    length = [14, 17].sample
+    digits = [4] + Array.new(length) { Random.rand(10) }
   else
     raise "unhandled type: #{type}"
   end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -401,6 +401,100 @@ describe CreditCardSanitizer do
           end
         end
 
+        describe "bc_global" do
+          it "sanitizes BC Global cards ungrouped" do
+            assert_equal "Hello 389831▇▇▇▇2956 there", @sanitizer.sanitize!("Hello 38983157382956 there")
+          end
+
+          it "sanitizes BC Global cards grouped [4, 4, 4, 4]" do
+            assert_equal "Hello 6541 13▇▇ ▇▇▇▇ 9073 there", @sanitizer.sanitize!("Hello 6541 1329 6757 9073 there")
+            assert_equal "Hello 6541 11▇▇ ▇▇▇▇ 7856 there", @sanitizer.sanitize!("Hello 6541 1173 2388 7856 there")
+          end
+
+          it "does not sanitize BC Global cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 6541 13 29 6757 90 73 there")
+          end
+        end
+
+        describe "carte_blanche" do
+          it "sanitizes Carte Blanche cards ungrouped" do
+            assert_equal "Hello 389831▇▇▇▇2956 there", @sanitizer.sanitize!("Hello 38983157382956 there")
+          end
+
+          it "sanitizes Carte Blanche cards grouped [4, 6, 4]" do
+            assert_equal "Hello 3898 31▇▇▇▇ 2956 there", @sanitizer.sanitize!("Hello 3898 315738 2956 there")
+            assert_equal "Hello 3894 25▇▇▇▇ 2945 there", @sanitizer.sanitize!("Hello 3894 255759 2945 there")
+          end
+
+          it "does not sanitize Carte Blanche cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 3898 31573 82956 there")
+          end
+        end
+
+        describe "insta_payment" do
+          it "sanitizes Insta Payment cards ungrouped" do
+            assert_equal "Hello 637129▇▇▇▇▇▇0358 there", @sanitizer.sanitize!("Hello 6371297163350358 there")
+          end
+
+          it "sanitizes Insta Payment cards grouped [4, 4, 4, 4]" do
+            assert_equal "Hello 6372 14▇▇ ▇▇▇▇ 7480 there", @sanitizer.sanitize!("Hello 6372 1422 0256 7480 there")
+            assert_equal "Hello 6370 28▇▇ ▇▇▇▇ 9403 there", @sanitizer.sanitize!("Hello 6370 2848 4023 9403 there")
+            assert_equal "Hello 6374 30▇▇ ▇▇▇▇ 6378 there", @sanitizer.sanitize!("Hello 6374 3055 8460 6378 there")
+          end
+
+          it "does not sanitize Insta Payment cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 63721422 0256 7480 there")
+          end
+        end
+
+        describe "korean_local" do
+          it "sanitizes Korean Local cards ungrouped" do
+            assert_equal "Hello 959522▇▇▇▇▇▇7347 there", @sanitizer.sanitize!("Hello 9595220257947347 there")
+          end
+
+          it "sanitizes Korean Local cards grouped [4, 4, 4, 4]" do
+            assert_equal "Hello 9600 20▇▇ ▇▇▇▇ 7063 there", @sanitizer.sanitize!("Hello 9600 2007 6943 7063 there")
+            assert_equal "Hello 9275 54▇▇ ▇▇▇▇ 8061 there", @sanitizer.sanitize!("Hello 9275 5472 7894 8061 there")
+            assert_equal "Hello 9932 07▇▇ ▇▇▇▇ 7203 there", @sanitizer.sanitize!("Hello 9932 0768 8710 7203 there")
+          end
+
+          it "does not sanitize Korean Local cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 92755472 7894 8061 there")
+          end
+        end
+
+        describe "union_pay" do
+          it "sanitizes union_pay cards ungrouped" do
+            assert_equal "Hello 629629▇▇▇▇▇▇▇▇▇3314 there", @sanitizer.sanitize!("Hello 6296291900662503314 there")
+          end
+
+          it "sanitizes Union Pay cards grouped [4, 4, 4, 4], [4, 4, 4, 4, 1], [4, 4, 4, 4, 2], [4, 4, 4, 4, 3]" do
+            assert_equal "Hello 6252 68▇▇ ▇▇▇▇ 4962 there", @sanitizer.sanitize!("Hello 6252 6822 8279 4962 there")
+            assert_equal "Hello 6245 58▇▇ ▇▇▇▇ ▇465 6 there", @sanitizer.sanitize!("Hello 6245 5863 5509 5465 6 there")
+            assert_equal "Hello 6286 83▇▇ ▇▇▇▇▇ ▇▇55 30 there", @sanitizer.sanitize!("Hello 6286 8374 42593 6055 30 there")
+            assert_equal "Hello 6216 58▇▇ ▇▇▇▇ ▇▇▇3 037 there", @sanitizer.sanitize!("Hello 6216 5876 4391 9883 037 there")
+          end
+
+          it "does not sanitize Union Pay cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 6252682282 79 4962 there")
+          end
+        end
+
+        describe "visa_master" do
+          it "sanitizes visa_master cards ungrouped" do
+            assert_equal "Hello 405249▇▇▇▇▇▇1894 there", @sanitizer.sanitize!("Hello 4052495067081894 there")
+          end
+
+          it "sanitizes Visa Master cards grouped [4, 4, 4, 4], [4, 4, 4, 4, 3]" do
+            assert_equal "Hello 4993 95▇▇ ▇▇▇▇ 7676 there", @sanitizer.sanitize!("Hello 4993 9547 0554 7676 there")
+            assert_equal "Hello 4673 62▇▇ ▇▇▇▇ ▇▇▇1 181 there", @sanitizer.sanitize!("Hello 4673 6276 7569 9641 181 there")
+          end
+
+          it "does not sanitize Visa Master cards grouped oddly" do
+            assert_nil @sanitizer.sanitize!("Hello 4993 95 47 05 54 76 76 there")
+          end
+        end
+
         # these numbers were generated via scripts/generate_card.rb
         it "does not santitize a visa credit card number embedded in a number" do
           assert_nil @sanitizer.sanitize!("04881621594644972")
@@ -450,6 +544,29 @@ describe CreditCardSanitizer do
           assert_nil @sanitizer.sanitize!("0630487115747")
         end
 
+        it "does not sanitize a bc_global card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("165419534844545021")
+        end
+
+        it "does not sanitize a carte_blanche card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("23891686932649923")
+        end
+
+        it "does not sanitize an insta_payment card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("22637893050918983222")
+        end
+
+        it "does not sanitize a korean_local card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("12983392890788018712")
+        end
+
+        it "does not sanitize a union_pay card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("15624053108599990468815")
+        end
+
+        it "does not sanitize a visa_master card number embedded in a number" do
+          assert_nil @sanitizer.sanitize!("22446465232914667322")
+        end
 
         it "does not sanitize ARN numbers" do
           assert_nil @sanitizer.sanitize!("74537606287640125960797 and 74537606281640124230958")
@@ -542,6 +659,30 @@ describe CreditCardSanitizer do
 
     it "returns true for forbrugsforeningen cards" do
       assert @sanitizer.send(:valid_company_prefix?, "6007221000000000")
+    end
+
+    it "returns true for bc_global cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "6541953484454502")
+    end
+
+    it "returns true for carte_blanche cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "38916869326499")
+    end
+
+    it "returns true for insta_payment cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "6378930509189832")
+    end
+
+    it "returns true for korean_local cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "9833928907880187")
+    end
+
+    it "returns true for union_pay cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "6240531085999904688")
+    end
+
+    it "returns true for visa_master cards" do
+      assert @sanitizer.send(:valid_company_prefix?, "4464652329146673")
     end
 
     it "returns true for full range laser cards" do


### PR DESCRIPTION
### Update sanitization regexes:
Jira: https://zendesk.atlassian.net/browse/DDEL-629

### Task:
Updating existing regexes with the following requested by customer:

> Amex Card: ^3[47][0-9]{13}$
> 
> BCGlobal: ^(6541|6556)[0-9]{12}$
> 
> Carte Blanche Card: ^389[0-9]{11}$
> 
> Diners Club Card: ^3(?:0[0-5]|[68][0-9])[0-9]{11}$
> 
> Discover Card: ^65[4-9][0-9]{13}|64[4-9][0-9]{13}|6011[0-9]{12}|(622(?:12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|9[01][0-9]|92[0-5])[0-9]{10})$
> 
> Insta Payment Card: ^63[7-9][0-9]{13}$
> 
> JCB Card: ^(?:2131|1800|35\d{3})\d{11}$
> 
> KoreanLocalCard: ^9[0-9]{15}$
> 
> Laser Card: ^(6304|6706|6709|6771)[0-9]{12,15}$
> 
> Maestro Card: ^(5018|5020|5038|5893|6304|6759|6761|6762|6763)[0-9]{8,15}$
> 
> Mastercard: ^5[1-5][0-9]{14}$
> 
> Solo Card: ^(6334|6767)[0-9]{12}|(6334|6767)[0-9]{14}|(6334|6767)[0-9]{15}$
> 
> Switch Card: ^(4903|4905|4911|4936|6333|6759)[0-9]{12}|(4903|4905|4911|4936|6333|6759)[0-9]{14}|(4903|4905|4911|4936|6333|6759)[0-9]{15}|564182[0-9]{10}|564182[0-9]{12}|564182[0-9]{13}|633110[0-9]{10}|633110[0-9]{12}|633110[0-9]{13}$
> 
> Union Pay Card: ^(62[0-9]{14,17})$
> 
> Visa Card: ^4[0-9]{12}(?:[0-9]{3})?$
> 
> Visa Master Card: ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})$

### Outcome:
<img width="1232" alt="image" src="https://github.com/zendesk/credit_card_sanitizer/assets/108755584/c50657eb-33f8-4dc6-98ed-0256ec405237">

<img width="1238" alt="image" src="https://github.com/zendesk/credit_card_sanitizer/assets/108755584/e2c6c9c1-dfa1-4a3c-84cc-943aa9662f8d">


