### PR TITLE
[DP-2085] Parse flanked Japanese/Chinese characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.2.0
+
+- **BREAKING**: Introduce a new `allow_flanking_by_no_space_languages` option to explicitly control sanitization of credit card numbers flanked by Japanese/Chinese characters. When using default options (`parse_flanking: false`), these numbers are no longer sanitized by default. Set `allow_flanking_by_no_space_languages: true` to restore the previous behavior.
+
 ## v1.1.0
 
 - Ensure the gem works when using frozen strings.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (1.1.0)
+    credit_card_sanitizer (1.2.0)
       luhn_checksum (~> 0.1)
       tracking_number (~> 0.10.3)
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ is also returned.
 
 ### Configuration
 
-| Name                       | Description                                                                                  |
-| -------------------------- | -------------------------------------------------------------------------------------------- |
-| `replacement_token`        | The character used to replace digits of the credit number.  The default is `▇`.              |
-| `expose_first`             | The number of leading digits of the credit card number to leave intact. The default is `6`.  |
-| `expose_last`              | The number of trailing digits of the credit card number to leave intact. The default is `4`. |
-| `use_groupings`            | Use known card number groupings to reduce false positives. The default is `false`.           |
-| `exclude_tracking_numbers` | Identify shipping tracking numbers and don't truncate them. The default is `false`.          |
-| `return_changes`           | When `true`, `sanitize!` returns a list of redactions made. The default is `false`.          |
+| Name                                | Description                                                                                        |
+| ----------------------------------- |----------------------------------------------------------------------------------------------------|
+| `replacement_token`                 | The character used to replace digits of the credit number.  The default is `▇`.                    |
+| `expose_first`                      | The number of leading digits of the credit card number to leave intact. The default is `6`.        |
+| `expose_last`                       | The number of trailing digits of the credit card number to leave intact. The default is `4`.       |
+| `use_groupings`                     | Use known card number groupings to reduce false positives. The default is `false`.                 |
+| `exclude_tracking_numbers`          | Identify shipping tracking numbers and don't truncate them. The default is `false`.                |
+| `parse_flanking`                    | Only sanitize credit card numbers with valid prefixes/postfixes. The default is `false`.           |
+| `allow_flanking_by_no_space_languages`| Allow sanitization of credit cards flanked by Japanese/Chinese characters. The default is `false`. |
+| `return_changes`                    | When `true`, `sanitize!` returns a list of redactions made. The default is `false`.                |
 
 ### Default Replacement Level
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -55,6 +55,8 @@ class CreditCardSanitizer
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+|\/)|(?:[a-zA-Z][-+.a-zA-Z\d]{,9}):[^\s>]+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,30}/
+  # Languages that don't use spaces between words/characters and numbers
+  ACCEPTED_JAPANESE_CHINESE_CHARS = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/  # Japanese: Hiragana (あ-ゟ), Katakana (ア-ヿ), Kanji (一-鿿); Chinese: Hanzi (CJK Unified Ideographs)
 
   DEFAULT_OPTIONS = {
     replacement_token: "▇",
@@ -62,7 +64,8 @@ class CreditCardSanitizer
     expose_last: 4,
     use_groupings: false,
     exclude_tracking_numbers: false,
-    parse_flanking: false
+    parse_flanking: false,
+    allow_flanking_by_no_space_languages: false
   }.freeze
 
   attr_reader :settings
@@ -78,6 +81,8 @@ class CreditCardSanitizer
   # :expose_last - the number of ending digits that will not be redacted.
   # :use_groupings - require card number groupings to match to redact.
   # :exclude_tracking_numbers - do not redact valid shipping company tracking numbers.
+  # :parse_flanking - require valid context (prefix/postfix) around card numbers to redact.
+  # :allow_flanking_by_no_space_languages - allow redaction of card numbers flanked by Japanese/Chinese characters.
   #
   def initialize(options = {})
     @settings = DEFAULT_OPTIONS.merge(options)
@@ -193,7 +198,17 @@ class CreditCardSanitizer
   end
 
   def valid_context?(candidate, options)
-    !options[:parse_flanking] || valid_prefix?(candidate.prefix) && valid_postfix?(candidate.postfix)
+    flanked_by_no_space_languages = valid_flanking_by_no_space_languages?(candidate.prefix, candidate.postfix)
+
+    if flanked_by_no_space_languages
+      options[:allow_flanking_by_no_space_languages]
+    else
+      !options[:parse_flanking] || valid_prefix?(candidate.prefix) && valid_postfix?(candidate.postfix)
+    end
+  end
+
+  def valid_flanking_by_no_space_languages?(prefix, postfix)
+    (prefix && ACCEPTED_JAPANESE_CHINESE_CHARS.match(prefix[-1])) || (postfix && ACCEPTED_JAPANESE_CHINESE_CHARS.match(postfix[0]))
   end
 
   def valid_prefix?(prefix)

--- a/lib/credit_card_sanitizer/version.rb
+++ b/lib/credit_card_sanitizer/version.rb
@@ -1,3 +1,3 @@
 class CreditCardSanitizer
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -232,6 +232,34 @@ describe CreditCardSanitizer do
         it "sanitizes credit card numbers flanked by letters" do
           assert_equal "a411111▇▇▇▇▇▇1111b", @sanitizer.sanitize!("a4111111111111111b")
         end
+
+        describe "when allow_flanking_by_no_space_languages is true" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(parse_flanking: false, allow_flanking_by_no_space_languages: true)
+          end
+
+          it "sanitizes credit card numbers that are flanked by Japanese text" do
+            assert_equal "返金してください。カード番号は424242▇▇▇▇▇▇4242です。", @sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
+          end
+
+          it "sanitizes credit card numbers flanked only on the left by Japanese text" do
+            assert_equal "カード番号は424242▇▇▇▇▇▇4242", @sanitizer.sanitize!("カード番号は4242424242424242")
+          end
+
+          it "sanitizes credit card numbers flanked only on the right by Japanese text" do
+            assert_equal "424242▇▇▇▇▇▇4242です。", @sanitizer.sanitize!("4242424242424242です。")
+          end
+        end
+
+        describe "when allow_flanking_by_no_space_languages is false" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(parse_flanking: false, allow_flanking_by_no_space_languages: false)
+          end
+
+          it "does not sanitize credit card numbers that are flanked by Japanese text (by default)" do
+            assert_nil @sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
+          end
+        end
       end
 
       describe "when true" do
@@ -261,6 +289,34 @@ describe CreditCardSanitizer do
 
         it "does not sanitize credit card numbers flanked by letters" do
           assert_nil @sanitizer.sanitize!("a4111111111111111b")
+        end
+
+        describe "when allow_flanking_by_no_space_languages is true" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(parse_flanking: true, allow_flanking_by_no_space_languages: true)
+          end
+
+          it "sanitizes credit card numbers that are flanked by Japanese text" do
+            assert_equal "返金してください。カード番号は424242▇▇▇▇▇▇4242です。", @sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
+          end
+
+          it "sanitizes credit card numbers flanked only on the left by Japanese text" do
+            assert_equal "カード番号は424242▇▇▇▇▇▇4242", @sanitizer.sanitize!("カード番号は4242424242424242")
+          end
+
+          it "sanitizes credit card numbers flanked only on the right by Japanese text" do
+            assert_equal "424242▇▇▇▇▇▇4242です。", @sanitizer.sanitize!("4242424242424242です。")
+          end
+        end
+
+        describe "when allow_flanking_by_no_space_languages is false" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(parse_flanking: true, allow_flanking_by_no_space_languages: false)
+          end
+
+          it "does not sanitize credit card numbers that are flanked by Japanese text" do
+            assert_nil @sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
+          end
         end
       end
     end


### PR DESCRIPTION
# Context
We want to explicitly allow/disallow flanking Japanese/Chinese characters regardless  on the `parse_flanking` option. 

Currently, it's not possible to sanitize the credit card in the Japanese language when the `parse_flanking` is `TRUE`: 
```
返金してください。カード番号は4242424242424242です。 -> 返金してください。カード番号は4242424242424242です。
```


 Due to I'm introducing the `allow_flanking_no_spaces_languages` boolean options, which will change the behaviour of this gem:
- if `true`: flanking Japanese/Chinese characters are allowed
- if `false`: flanking Japanese/Chinese characters are **NOT** allowed


## Before (v1.1.x):
```
  sanitizer = CreditCardSanitizer.new(parse_flanking: false)
  sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
  # => "返金してください。カード番号は424242▇▇▇▇▇▇4242です。"
```
##  After (v1.2.x) - DEFAULT BEHAVIOR CHANGED:
```
  sanitizer = CreditCardSanitizer.new(parse_flanking: false)
  sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
  # => nil  # ⚠️ NO LONGER SANITIZED BY DEFAULT
```

## To restore previous behavior:
###   If you had `parse_flanking: false`
```
  sanitizer = CreditCardSanitizer.new(
    parse_flanking: false,
    allow_flanking_no_spaces_languages: true  # ✅ Add this option
  )
  sanitizer.sanitize!("返金してください。カード番号は4242424242424242です。")
  # => "返金してください。カード番号は424242▇▇▇▇▇▇4242です。"
```

### If you had `parse_flanking: true`

  No action required - Japanese-flanked credit cards were not sanitized before and still won't be by default.

## If you want to start sanitizing Japanese-flanked credit cards:
```
  sanitizer = CreditCardSanitizer.new(
    parse_flanking: true/false,
    allow_flanking_no_spaces_languages: true  # ✅ Add this to sanitize Japanese-flanked cards
  )
```