### PR TITLE
[DP-2212] Prevent redactions in {{placeholders}}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.3.0
+
+- Introduce a new `protect_placeholders` option (default: `false`), `placeholder_open` and `placeholder_close` options (default: `{{` and `}}`) to prevent sanitization of credit card numbers within placeholders `{{...}}`.
+
 ## v1.2.0
 
 - **BREAKING**: Introduce a new `allow_flanking_by_no_space_languages` option to explicitly control sanitization of credit card numbers flanked by Japanese/Chinese characters. When using default options (`parse_flanking: false`), these numbers are no longer sanitized by default. Set `allow_flanking_by_no_space_languages: true` to restore the previous behavior.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (1.2.0)
+    credit_card_sanitizer (1.3.0)
       luhn_checksum (~> 0.1)
       tracking_number (~> 0.10.3)
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,19 @@ is also returned.
 
 ### Configuration
 
-| Name                                | Description                                                                                        |
-| ----------------------------------- |----------------------------------------------------------------------------------------------------|
-| `replacement_token`                 | The character used to replace digits of the credit number.  The default is `▇`.                    |
-| `expose_first`                      | The number of leading digits of the credit card number to leave intact. The default is `6`.        |
-| `expose_last`                       | The number of trailing digits of the credit card number to leave intact. The default is `4`.       |
-| `use_groupings`                     | Use known card number groupings to reduce false positives. The default is `false`.                 |
-| `exclude_tracking_numbers`          | Identify shipping tracking numbers and don't truncate them. The default is `false`.                |
-| `parse_flanking`                    | Only sanitize credit card numbers with valid prefixes/postfixes. The default is `false`.           |
-| `allow_flanking_by_no_space_languages`| Allow sanitization of credit cards flanked by Japanese/Chinese characters. The default is `false`. |
-| `return_changes`                    | When `true`, `sanitize!` returns a list of redactions made. The default is `false`.                |
+| Name                                   | Description                                                                                       |
+|----------------------------------------|---------------------------------------------------------------------------------------------------|
+| `replacement_token`                    | The character used to replace digits of the credit number.  The default is `▇`.                   |
+| `expose_first`                         | The number of leading digits of the credit card number to leave intact. The default is `6`.       |
+| `expose_last`                          | The number of trailing digits of the credit card number to leave intact. The default is `4`.      |
+| `use_groupings`                        | Use known card number groupings to reduce false positives. The default is `false`.                |
+| `exclude_tracking_numbers`             | Identify shipping tracking numbers and don't truncate them. The default is `false`.               |
+| `parse_flanking`                       | Only sanitize credit card numbers with valid prefixes/postfixes. The default is `false`.          |
+| `allow_flanking_by_no_space_languages` | Allow sanitization of credit cards flanked by Japanese/Chinese characters. The default is `false`.|
+| `protect_placeholders`                 | Do not sanitize numbers within placeholders. The default is `false`.                              |
+| `placeholder_open`                     | Opening delimiter for placeholders (e.g., `{{`, `<%`, `${`). The default is `{{`.                 |
+| `placeholder_close`                    | Closing delimiter for placeholders (e.g., `}}`, `%>`, `}`). The default is `}}`.                  |
+| `return_changes`                       | When `true`, `sanitize!` returns a list of redactions made. The default is `false`.               |
 
 ### Default Replacement Level
 
@@ -103,6 +106,34 @@ The `exclude_tracking_numbers` option runs candidate numbers about to be truncat
 Turning on this option reduces the likelihood of a tracking number being identified as a false positive
 and truncated. However, it runs the risk of an actual credit card number being incorrectly identified as
 a shipping tracking number, and not truncated.
+
+### Protecting Placeholders
+
+The `protect_placeholders` option prevents sanitization of credit card numbers within placeholders.
+By default, the gem protects double curly brace placeholders (`{{...}}`),
+but you can configure different delimiters:
+
+```ruby
+# Default: protect {{ }} placeholders
+sanitizer = CreditCardSanitizer.new(protect_placeholders: true)
+sanitizer.sanitize!("{{ticket.field_4111111111111111}}")  # => nil (not sanitized)
+
+# ERB-style placeholders
+sanitizer = CreditCardSanitizer.new(
+  protect_placeholders: true,
+  placeholder_open: "<%",
+  placeholder_close: "%>"
+)
+sanitizer.sanitize!("<% ticket.field_4111111111111111 %>")  # => nil (not sanitized)
+
+# ES6 template literals
+sanitizer = CreditCardSanitizer.new(
+  protect_placeholders: true,
+  placeholder_open: "${",
+  placeholder_close: "}"
+)
+sanitizer.sanitize!("${field_4111111111111111}")  # => nil (not sanitized)
+```
 
 ### Exclusion of URLs and phone numbers
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -65,7 +65,10 @@ class CreditCardSanitizer
     use_groupings: false,
     exclude_tracking_numbers: false,
     parse_flanking: false,
-    allow_flanking_by_no_space_languages: false
+    allow_flanking_by_no_space_languages: false,
+    protect_placeholders: false,
+    placeholder_open: "{{",
+    placeholder_close: "}}"
   }.freeze
 
   attr_reader :settings
@@ -83,6 +86,9 @@ class CreditCardSanitizer
   # :exclude_tracking_numbers - do not redact valid shipping company tracking numbers.
   # :parse_flanking - require valid context (prefix/postfix) around card numbers to redact.
   # :allow_flanking_by_no_space_languages - allow redaction of card numbers flanked by Japanese/Chinese characters.
+  # :protect_placeholders - do not redact numbers within placeholders.
+  # :placeholder_open - opening delimiter for placeholders (default: "{{").
+  # :placeholder_close - closing delimiter for placeholders (default: "}}").
   #
   def initialize(options = {})
     @settings = DEFAULT_OPTIONS.merge(options)
@@ -198,6 +204,10 @@ class CreditCardSanitizer
   end
 
   def valid_context?(candidate, options)
+    if options[:protect_placeholders]
+      return false if within_placeholder?(candidate.prefix, candidate.postfix, options)
+    end
+
     flanked_by_no_space_languages = valid_flanking_by_no_space_languages?(candidate.prefix, candidate.postfix)
 
     if flanked_by_no_space_languages
@@ -209,6 +219,36 @@ class CreditCardSanitizer
 
   def valid_flanking_by_no_space_languages?(prefix, postfix)
     (prefix && ACCEPTED_JAPANESE_CHINESE_CHARS.match(prefix[-1])) || (postfix && ACCEPTED_JAPANESE_CHINESE_CHARS.match(postfix[0]))
+  end
+
+  # Checks if the number is within a placeholder
+  def within_placeholder?(prefix, postfix, options)
+    placeholder_open = options[:placeholder_open]
+    placeholder_close = options[:placeholder_close]
+
+    return false if placeholder_open.nil? || placeholder_open.empty? || placeholder_close.nil? || placeholder_close.empty?
+
+    last_open_index = prefix.rindex(placeholder_open)
+    return false unless last_open_index
+
+    last_close_index = prefix.rindex(placeholder_close)
+
+    # Check if there's an unclosed opening delimiter
+    has_unclosed_opening = last_close_index.nil? || last_open_index > last_close_index
+    return false unless has_unclosed_opening
+
+    # Check if postfix has a closing delimiter
+    first_close_in_postfix = postfix.index(placeholder_close)
+    return false unless first_close_in_postfix
+
+    # Check if there's an opening delimiter before the first closing in postfix
+    # If so, the closing doesn't belong to our opening (malformed/nested case)
+    first_open_in_postfix = postfix.index(placeholder_open)
+    if first_open_in_postfix && first_open_in_postfix < first_close_in_postfix
+      return false
+    end
+
+    true
   end
 
   def valid_prefix?(prefix)

--- a/lib/credit_card_sanitizer/version.rb
+++ b/lib/credit_card_sanitizer/version.rb
@@ -1,3 +1,3 @@
 class CreditCardSanitizer
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -195,6 +195,91 @@ describe CreditCardSanitizer do
       assert_nil @sanitizer.sanitize!("612999921404471347800000")
     end
 
+    describe "protect_placeholders option" do
+      describe "when true" do
+        before do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true)
+        end
+
+        it "does not sanitize numbers within placeholders" do
+          assert_nil @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}}")
+          assert_nil @sanitizer.sanitize!("Hello {{ticket.ticket_field_option_title_4418815038484}} there")
+          assert_nil @sanitizer.sanitize!("Process {{ticket.id}} for card {{ticket.field_378282246310005}}. Please wait.")
+          assert_nil @sanitizer.sanitize!("{{ticket.ticket_field_4111111111111111.custom_fields.order_status.title}}")
+          assert_nil @sanitizer.sanitize!("{{field_4418815038484}} and {{field_4111111111111111}} and {{field_378282246310005}}")
+        end
+
+        it "sanitizes credit card numbers that look like placeholders but are not" do
+          # No closing }} so not a valid placeholder
+          assert_equal "{{ticket.ticket_field_441881▇▇▇8484", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484")
+          # No opening {{ so not a valid placeholder
+          assert_equal "ticket.ticket_field_441881▇▇▇8484}}", @sanitizer.sanitize!("ticket.ticket_field_4418815038484}}")
+          # Malformed: opening {{ in postfix before closing }} - not a valid placeholder
+          assert_equal "{{field_411111▇▇▇▇▇▇1111 {{test}}", @sanitizer.sanitize!("{{field_4111111111111111 {{test}}")
+        end
+
+        it "sanitizes real credit cards while protecting placeholders in mixed content" do
+          assert_equal "{{field_4418815038484}} but card 411111▇▇▇▇▇▇1111", @sanitizer.sanitize!("{{field_4418815038484}} but card 4111111111111111")
+          assert_equal "Card 555555▇▇▇▇▇▇4444 and {{field_4418815038484}} and card 378282▇▇▇▇▇0005", @sanitizer.sanitize!("Card 5555555555554444 and {{field_4418815038484}} and card 378282246310005")
+        end
+
+        it "sanitizes credit card numbers BETWEEN placeholders (not inside)" do
+          assert_equal "{{first}} 411111▇▇▇▇▇▇1111 {{second}}", @sanitizer.sanitize!("{{first}} 4111111111111111 {{second}}")
+          assert_equal "{{ticket.ticket_field_4418815038484}} Card 555555▇▇▇▇▇▇4444 {{ticket.ticket_field_4418815038484}}", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}} Card 5555555555554444 {{ticket.ticket_field_4418815038484}}")
+        end
+      end
+
+      describe "when false (default)" do
+        before do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: false)
+        end
+
+        it "sanitizes numbers within placeholders like any other credit card" do
+          assert_equal "{{ticket.ticket_field_441881▇▇▇8484}}", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}}")
+        end
+
+        it "sanitizes all credit card numbers regardless of context" do
+          assert_equal "{{field_441881▇▇▇8484}} card 411111▇▇▇▇▇▇1111", @sanitizer.sanitize!("{{field_4418815038484}} card 4111111111111111")
+        end
+
+        it "sanitizes multiple placeholders with credit card numbers" do
+          assert_equal "{{field_441881▇▇▇8484}} and {{field_411111▇▇▇▇▇▇1111}}", @sanitizer.sanitize!("{{field_4418815038484}} and {{field_4111111111111111}}")
+        end
+      end
+
+      describe "with custom placeholder delimiters" do
+        it "protects ERB-style placeholders" do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true, placeholder_open: "<%", placeholder_close: "%>")
+          assert_nil @sanitizer.sanitize!("<% ticket.field_4418815038484 %>")
+          assert_nil @sanitizer.sanitize!("Hello <% field_4111111111111111 %> there")
+        end
+
+        it "protects ES6-style template literals" do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true, placeholder_open: "${", placeholder_close: "}")
+          assert_nil @sanitizer.sanitize!("${field_4418815038484}")
+          assert_nil @sanitizer.sanitize!("Process ${id} for card ${field_378282246310005}")
+        end
+
+        it "sanitizes when custom delimiters don't match" do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true, placeholder_open: "<%", placeholder_close: "%>")
+          # These use {{ }} but we configured <% %>, so they should be sanitized
+          assert_equal "{{ticket.ticket_field_441881▇▇▇8484}}", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}}")
+        end
+
+        it "handles empty placeholder delimiters" do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true, placeholder_open: "", placeholder_close: "")
+          # Empty delimiters should disable placeholder protection
+          assert_equal "{{ticket.ticket_field_441881▇▇▇8484}}", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}}")
+        end
+
+        it "handles nil placeholder delimiters" do
+          @sanitizer = CreditCardSanitizer.new(protect_placeholders: true, placeholder_open: nil, placeholder_close: nil)
+          # Nil delimiters should disable placeholder protection
+          assert_equal "{{ticket.ticket_field_441881▇▇▇8484}}", @sanitizer.sanitize!("{{ticket.ticket_field_4418815038484}}")
+        end
+      end
+    end
+
     it "should sanitize a credit card number with an expiration date" do
       assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03/2015", @sanitizer.sanitize!("4111 1111 1111 1111 03/2015")
       assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03/15", @sanitizer.sanitize!("4111 1111 1111 1111 03/15")


### PR DESCRIPTION
Adds a new `protect_placeholders` option (default: false) to prevent the sanitizer from redacting numbers within placeholders like `{{ticket.ticket_field_4418815038484}}`.

 By `default protect_placeholders` is disabled, so there is no need to do anything after bumping the gem to the newer version if this feature is not needed.


Introduces a new protect_placeholders option that:
- Detects when a number sequence is within a placeholder using `{{` and `}}` delimiters (by default)
 - Skips sanitization of numbers inside valid placeholders
 - Still sanitizes real credit card numbers between or outside placeholders (`{{first}} 4418815038484 {{second}}`)
 - Handles edge cases like malformed placeholders (unclosed {{, nested delimiters, etc.)


# Manual tests
1. I created the Ticket's field called "Special Order Number" with "proper" Field ID that looks like credit card (in rails console using SQL insert :blush: )
<img width="1471" height="874" alt="image" src="https://github.com/user-attachments/assets/890f9204-9b8b-49cf-bbdc-9de2ed989d42" />

2. Then added it to the Default Ticket Form:
<img width="1780" height="874" alt="image" src="https://github.com/user-attachments/assets/e2eff1b8-63fc-4a2a-9d52-480557da38b9" />

 
3. And at the end, created the ticket, with two comments:
- first when the `protect_placeholders_in_credit_card_sanitization` feature flag was disabled
- second when the `protect_placeholders_in_credit_card_sanitization` feature flag was enabled

#### THE MESSAGE I USED:
```
New/Old behaviour:
4418815038484 => {{ticket.ticket_field_4418815038484}}
```

<img width="1780" height="874" alt="image" src="https://github.com/user-attachments/assets/5daa5a69-bbcd-4be9-8c81-d00ba69d842f" />


